### PR TITLE
FEAT: Mask sites where filters are applied

### DIFF
--- a/bin/filter_cohort.py
+++ b/bin/filter_cohort.py
@@ -1,5 +1,36 @@
 #!/usr/local/bin/python
+"""
+Filter Cohort - MAF Processing and Flagging Script
 
+This script processes a Mutation Annotation Format (MAF) file to filter variants by specific criteria and 
+generates a final filtered MAF along with an output of flagged regions in BED format.
+
+Command-line Arguments
+----------------------
+maf_path : str
+    Path to the gzipped input MAF file.
+samp_name : str
+    Output sample name.
+repetitive_variant_thr : int
+    Minimum occurrences threshold to flag a repetitive variant.
+somatic_vaf_boundary : float
+    VAF threshold to classify somatic mutations.
+
+Authors
+-------
+Author  : Ferriol Calvet (@FerriolCalvet)
+Email   : ferriol.calvet@irbbarcelona.org
+
+Contributors
+------------
+- Raquel Blanco - @rblancomi (raquel.blanco@irbbarcelona.org)
+- Federica Brando - @FedericaBrando (federica.brando@irbbarcelona.org)
+
+Usage
+-----
+>>> python filter_cohort.py path/to/input.maf.gz output_sample_name 10 0.05
+
+"""
 import argparse
 import logging
 

--- a/bin/merge_annotation_depths.py
+++ b/bin/merge_annotation_depths.py
@@ -1,5 +1,35 @@
 #!/usr/local/bin/python
+"""
+Merge Annotation and Depth Files
 
+This module provides functionalities to merge mutation annotation files with depth files. Additionally, It masks 
+flagged genomic regions, and generating output depth files for individual samples or sample groups as specified.
+
+Command-line Options
+--------------------
+--annotation : str
+    Path to the input annotation file.
+--depths : str
+    Path to the input depths file.
+--json_file : str, optional
+    JSON file specifying sample groups for output generation.
+--regions-to-filter : str
+    Path to the BED file containing regions to filter by setting their depths to zero.
+
+Authors
+-------
+Author  : Ferriol Calvet (@FerriolCalvet)
+Email   : ferriol.calvet@irbbarcelona.org
+
+Contributors
+------------
+- Raquel Blanco - @rblancomi (raquel.blanco@irbbarcelona.org)
+- Federica Brando - @FedericaBrando (federica.brando@irbbarcelona.org)
+
+Usage
+-----
+>>> python merge_annotation_depths.py --annotation path/to/annotation.tsv --depths path/to/depths.tsv --regions-to-filter path/to/regions.bed
+"""
 
 import click
 import json
@@ -47,7 +77,7 @@ def mask_panel_regions(annotated_depths, regions_to_filter):
     annotated_depths.loc[mask, annotated_depths.columns.difference(COLS)] = 0
     
     LOG.info("Regions masked in depths file: %s", mask.sum())
-    
+    print(regions_to_mask[~regions_to_mask.set_index(["CHROM", "POS"]).index.isin(annotated_depths.set_index(["CHROM", "POS"]).index)])
 
     return annotated_depths
 

--- a/bin/merge_annotation_depths.py
+++ b/bin/merge_annotation_depths.py
@@ -4,52 +4,96 @@
 import click
 import json
 import pandas as pd
+import logging
 
-def annotate_depths(annotation_file, depths_file, json_f):
+# Logging
+logging.basicConfig(
+    format="%(asctime)s | %(levelname)s | %(name)s - %(message)s", level=logging.DEBUG, datefmt="%m/%d/%Y %I:%M:%S %p"
+)
+LOG = logging.getLogger("merge_annotation_depths")
+
+# Globals
+COLS = ["CHROM", "POS", "CONTEXT"]
+
+# Functions
+def preprocess(annots, depths):
     """
-    INFO
+    Merge annotation and depths files.
     """
+    LOG.info("Preprocessing annotation and depths files...")
+    _depths = pd.read_csv(depths, sep = "\t", header = 0)
+    _annots = pd.read_csv(annots, sep = "\t", header = 0)
 
-    raw_depths = pd.read_csv(depths_file, sep = "\t", header = 0)
-    annotations = pd.read_csv(annotation_file, sep = "\t", header = 0)
+    annot_depth =  _depths.merge(_annots, on = ["CHROM", "POS"], how = 'left').fillna(value={'CONTEXT': '-'})
 
-    annotated_depths = raw_depths.merge(annotations, on = ["CHROM", "POS"], how = 'left')
+    sample_columns = annot_depth.columns.difference(COLS).tolist()
+    rename_map = {col: col.split('.')[0] for col in sample_columns} # Dict to remove the .*.bam suffix
 
-    del raw_depths
-    del annotations
+    LOG.info("Samples: %s", list(rename_map.values())) # List of samples without the .*.bam suffix
 
-    print(annotated_depths.head())
+    # Place COLS=[CHROM, POS, CONTEXT] columns at the beginning then the rest of the columns
+    return annot_depth[COLS + sample_columns].rename(columns=rename_map), list(rename_map.values())
 
-    annotated_depths["CONTEXT"] = annotated_depths["CONTEXT"].fillna('-')
-    sample_columns = [x for x in annotated_depths.columns if x not in ["CHROM", "POS", "CONTEXT"] ]
-    annotated_depths = annotated_depths[["CHROM", "POS", "CONTEXT"] + sample_columns]
-    sample_columns_first = [ str(x).split('.')[0] for x in sample_columns ]
-    annotated_depths.columns = ["CHROM", "POS", "CONTEXT"] + sample_columns_first
+
+def mask_panel_regions(annotated_depths, regions_to_filter):
+    """
+    Mask regions flagged in the BED file by assigning depth 0 to them.
+    """
+    LOG.info("Masking regions --> Assign depth 0 to regions flagged in the BED file")
+    regions_to_mask = pd.read_csv(regions_to_filter, usecols=[0,1,3], sep = "\t", names=["CHROM", "POS", "FILTERS"])
+
+    LOG.debug("Regions to mask: %s", regions_to_mask.drop_duplicates().shape[0])
+    mask = (annotated_depths.set_index(["CHROM", "POS"]).index.isin(regions_to_mask.set_index(["CHROM", "POS"]).index))
+    annotated_depths.loc[mask, annotated_depths.columns.difference(COLS)] = 0
+    
+    LOG.info("Regions masked in depths file: %s", mask.sum())
+    
+
+    return annotated_depths
+
+
+def output_annotate_dephts(annotated_depths, json_f, samples):
+    """
+    Output annotated depths file
+
+    Parameters
+    ----------
+    annotated_depths : pd.DataFrame
+        Annotated depths dataframe
+    json_f : str
+        JSON file with groups information
+    samples : list
+        List of samples
+    """
+    LOG.info("Outputting annotated depths file...")
+
+    # Output annotated depths file for all samples
     annotated_depths.to_csv("all_samples_indv.depths.tsv.gz",
                                 header=True,
                                 index=False,
                                 sep="\t")
 
-    if json_f:
+    try:
         with open(json_f, 'r') as file:
             groups_info = json.load(file)
-
+            LOG.info("JSON file found. Outputting annotated depths file for each group.")
+        
         for group_name, samples in groups_info.items():
             annotated_depths[group_name] = annotated_depths.loc[:,samples].sum(axis=1)
-            annotated_depths[["CHROM", "POS", "CONTEXT", group_name]].to_csv(f"{group_name}.depths.annotated.tsv.gz",
+            annotated_depths[COLS + [group_name]].to_csv(f"{group_name}.depths.annotated.tsv.gz",
                                                                                 sep = "\t",
                                                                                 header = True,
-                                                                                index = False)
-
-    else:
-        for sample in sample_columns_first:
-            annotated_depths[["CHROM", "POS", "CONTEXT", f"{sample}"]].to_csv(f"{sample}.depths.annotated.tsv.gz",
+                                                                                index = False)   
+    except (TypeError, FileNotFoundError):
+        LOG.warning("JSON file not found. Outputting annotated depths file for each sample.")
+        for sample in samples:
+            annotated_depths[COLS + [str(sample)]].to_csv(f"{sample}.depths.annotated.tsv.gz",
                                                                                 sep = "\t",
                                                                                 header = True,
                                                                                 index = False)
 
         annotated_depths["all_samples"] = annotated_depths.iloc[:,3:].sum(axis=1)
-        annotated_depths[["CHROM", "POS", "CONTEXT", "all_samples"]].to_csv(f"all_samples.depths.annotated.tsv.gz",
+        annotated_depths[COLS + ["all_samples"]].to_csv("all_samples.depths.annotated.tsv.gz",
                                                                             sep = "\t",
                                                                             header = True,
                                                                             index = False)
@@ -60,11 +104,22 @@ def annotate_depths(annotation_file, depths_file, json_f):
 @click.option('--annotation', type=click.Path(exists=True), help='Input annotation file')
 @click.option('--depths', type=click.Path(exists=True), help='Input depths file')
 @click.option('--json_file', type=click.Path(exists=True), help='JSON groups file')
+@click.option('--regions-to-filter', type=click.Path(), help='BED file with regions to filter')
 # @click.option('--output', type=click.Path(), help='Output annotated depths file')
+def main(annotation, depths, json_file, regions_to_filter):
+    LOG.info("Annotating depths file...")
 
-def main(annotation, depths, json_file):
-    click.echo(f"Annotating depths file...")
-    annotate_depths(annotation, depths, json_file)
+    # Preprocess annotation and depths files
+    annotated_depths, samples  = preprocess(annotation, depths)
+
+    print(annotated_depths.head())
+
+    # Mask regions flagged in the BED file
+    annotated_depths = mask_panel_regions(annotated_depths, regions_to_filter)
+
+    output_annotate_dephts(annotated_depths, json_file, samples)
+
+    LOG.info("Done!")
 
 if __name__ == '__main__':
     main()

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -1,7 +1,29 @@
 # from itertools import product
 import json
+import logging
+from functools import wraps
+
 import pandas as pd
 
+#  Logging
+FORMAT = "%(asctime)s | %(levelname)s | %(name)s - %(message)s"
+
+def setup_logging(func):
+    """
+    Decorator to setup logging for the function
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        level = logging.DEBUG
+
+        # logging setup
+        logging.basicConfig(
+            format="%(asctime)s | %(levelname)s | %(name)s - %(message)s",
+            level=level, datefmt="%m/%d/%Y %I:%M:%S %p"
+        )
+        return func(*args, **kwargs)
+
+    return wrapper
 
 def add_filter(old_filt, add_filt, filt_name):
     """

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -5,9 +5,16 @@ import pandas as pd
 
 def add_filter(old_filt, add_filt, filt_name):
     """
-    old filt is the current FILTER field value
-    add_filt is a boolean, either True or False
-    filt_name is the name that should be added in the FILTER field in case the add_filt value is True
+    Adds a filter to the FILTER field in the MAF dataframe
+
+    Parameters
+    ----------
+    old_filt : str
+        The current FILTER field value
+    add_filt : bool
+        Either True or False
+    filt_name : str
+        The name that should be added in the FILTER field in case the add_filt value is True
     """
     if add_filt:
         if old_filt == "PASS":

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -262,7 +262,15 @@ process {
         ext.canonical_only  = params.panel_with_canonical
     }
 
-    withName: 'FILTERBATCH|MERGEBATCH|FILTERPANEL|VCF2MAF|COMPUTE_MUTABILITY|MATRIX_CONCAT|COMPUTETRINUC|POSTPROCESSVEPPANEL|COMPUTEDEPTHS' {
+    withName: 'FILTERBATCH' {
+        publishDir       = [
+                mode: params.publish_dir_mode,
+                path: { "${params.outdir}/filterbatch/" },
+                pattern: "*.bed"
+        ]
+    }
+
+    withName: 'MERGEBATCH|FILTERPANEL|VCF2MAF|COMPUTE_MUTABILITY|MATRIX_CONCAT|COMPUTETRINUC|POSTPROCESSVEPPANEL|COMPUTEDEPTHS' {
         publishDir       = [
                 enabled : false
         ]

--- a/modules/local/annotatedepth/main.nf
+++ b/modules/local/annotatedepth/main.nf
@@ -13,6 +13,7 @@ process ANNOTATE_DEPTHS {
     tuple val(meta) , path(depths)
     tuple val(meta2), path(panel_all)
     path (json_groups)
+    tuple val(meta3), path(flagged_muts)
 
     output:
     // tuple val(meta), path("*.depths.annotated.tsv.gz") , emit: annotated_depths
@@ -32,7 +33,8 @@ process ANNOTATE_DEPTHS {
     merge_annotation_depths.py \\
         --annotation ${panel_all}.contexts \\
         --depths ${depths} \\
-        --json_file ${json_groups}
+        --json_file ${json_groups} \\
+        --regions-to-filter ${flagged_muts}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/filtermaf/main.nf
+++ b/modules/local/filtermaf/main.nf
@@ -14,7 +14,7 @@ process FILTER_BATCH {
 
     output:
     tuple val(meta), path("*.cohort.filtered.tsv.gz") , emit: cohort_maf
-    tuple val(meta), path("*discarded.bed")           , emit: discarded_muts
+    tuple val(meta), path("*.flagged-pos.bed")        , emit: flagged_muts
     path "versions.yml"                               , emit: versions
 
     when:

--- a/modules/local/filtermaf/main.nf
+++ b/modules/local/filtermaf/main.nf
@@ -14,6 +14,7 @@ process FILTER_BATCH {
 
     output:
     tuple val(meta), path("*.cohort.filtered.tsv.gz") , emit: cohort_maf
+    tuple val(meta), path("*discarded.bed")           , emit: discarded_muts
     path "versions.yml"                               , emit: versions
 
     when:

--- a/subworkflows/local/mutationpreprocessing/main.nf
+++ b/subworkflows/local/mutationpreprocessing/main.nf
@@ -88,6 +88,7 @@ workflow MUTATION_PREPROCESSING {
 
     emit:
     mafs                    = named_mafs
+    flagged_bed             = FILTERBATCH.out.flagged_muts
     somatic_mafs            = SOMATICMUTATIONS.out.mutations
     all_raw_vep_annotation  = SUMANNOTATION.out.tab_all
     bedfile_clean           = bedfile_updated


### PR DESCRIPTION
This PR includes several changes to mask the position where we applied these filters (flagged region):

- `repetitive_variant`
- `cohort_n_rich`, `cohort_n_rich_uni`
- `other_samples_snp`

These regions needs to be masked in the depth (depth=0) so that they are not passed to the analysis step.

```zsh
❯ cat all_samples_discarded.bed | head
chr1    11107661        11107661        FILTER.cohort_n_rich_uni
chr1    11108009        11108009        FILTER.cohort_n_rich_uni
chr1    11108412        11108412        FILTER.cohort_n_rich_uni
chr1    11109993        11109993        FILTER.cohort_n_rich_uni,FILTER.other_sample_SNP
chr1    11110011        11110011        FILTER.cohort_n_rich_uni
chr1    11110074        11110074        FILTER.cohort_n_rich_uni,FILTER.other_sample_SNP
```

The most important changes include splitting the `FILTERBATCH` process for better output management, including outputting flagged_regions.bed, adding new input to `ANNOTATE_DEPTHS`, and updating the `DEEPCSA` workflow to manage the dependancies between `MUTATION_PREPROCESSING`  and `ANNOTATE_DEPTHS`.

Related to #53 #118 #117

Closes #118

-----------------------------------------------------------------------------------------------
<details><summary><h3>CHANGES</h3></summary>
<p>

### Changes to `FILTERBATCH` Process:
* Split the `FILTERBATCH` process into its own section to manage its output directory separately (`conf/modules.config`).
* Added a new output path `flagged_muts` to the `FILTER_BATCH` process (`modules/local/filtermaf/main.nf`).

### Changes to `MUTATION_PREPROCESSING` Workflow:
* Emitted `flagged_bed` from the `FILTERBATCH` process in the `MUTATION_PREPROCESSING` workflow (`subworkflows/local/mutationpreprocessing/main.nf`).

### Changes to `DEEPCSA` Workflow:
* Updated the `DEEPCSA` workflow to include flagged_bed as `MUT_PREPROCESSING` output and pass it to `ANNOTATEDEPTHS` (`workflows/deepcsa.nf`). [[1]](diffhunk://#diff-87c636ed11c630b436dd28dc585de64022c0bbf406a7875587e2598a5a0c9cb5L204-R210) [[2]](diffhunk://#diff-87c636ed11c630b436dd28dc585de64022c0bbf406a7875587e2598a5a0c9cb5L215-L221)

### Changes to `ANNOTATE_DEPTHS` Process:
* Added a new input tuple `flagged_muts` to the `ANNOTATE_DEPTHS` process (`modules/local/annotatedepth/main.nf`).
* Updated the `merge_annotation_depths.py` command to include the `--regions-to-filter` parameter (`modules/local/annotatedepth/main.nf`).

</p>
</details> 
