### PR TITLE
Quick fix to make sample names match

### DIFF
--- a/bin/merge_annotation_depths.py
+++ b/bin/merge_annotation_depths.py
@@ -5,7 +5,7 @@ import click
 import json
 import pandas as pd
 
-def annotate_depths(annotation_file, depths_file, json_f):
+def annotate_depths(annotation_file, depths_file, json_f, input_file):
     """
     INFO
     """
@@ -23,8 +23,15 @@ def annotate_depths(annotation_file, depths_file, json_f):
     annotated_depths["CONTEXT"] = annotated_depths["CONTEXT"].fillna('-')
     sample_columns = [x for x in annotated_depths.columns if x not in ["CHROM", "POS", "CONTEXT"] ]
     annotated_depths = annotated_depths[["CHROM", "POS", "CONTEXT"] + sample_columns]
-    sample_columns_first = [ str(x).split('.')[0] for x in sample_columns ]
-    annotated_depths.columns = ["CHROM", "POS", "CONTEXT"] + sample_columns_first
+
+    input_csv = pd.read_table(input_file, sep = ',', header = 0)
+    bam2sample_dict = dict(zip(input_csv["bam"].astype(str).apply(lambda x: x.split("/")[-1]),
+                               input_csv["sample"].astype(str)
+                               )
+                            )
+    
+    sample_columns_correct = [ bam2sample_dict[str(x)] for x in sample_columns ]
+    annotated_depths.columns = ["CHROM", "POS", "CONTEXT"] + sample_columns_correct
     annotated_depths.to_csv("all_samples_indv.depths.tsv.gz",
                                 header=True,
                                 index=False,
@@ -42,7 +49,7 @@ def annotate_depths(annotation_file, depths_file, json_f):
                                                                                 index = False)
 
     else:
-        for sample in sample_columns_first:
+        for sample in sample_columns_correct:
             annotated_depths[["CHROM", "POS", "CONTEXT", f"{sample}"]].to_csv(f"{sample}.depths.annotated.tsv.gz",
                                                                                 sep = "\t",
                                                                                 header = True,
@@ -60,11 +67,12 @@ def annotate_depths(annotation_file, depths_file, json_f):
 @click.option('--annotation', type=click.Path(exists=True), help='Input annotation file')
 @click.option('--depths', type=click.Path(exists=True), help='Input depths file')
 @click.option('--json_file', type=click.Path(exists=True), help='JSON groups file')
+@click.option('--input_csv', type=click.Path(exists=True), help='Input CSV file')
 # @click.option('--output', type=click.Path(), help='Output annotated depths file')
 
-def main(annotation, depths, json_file):
+def main(annotation, depths, json_file, input_csv):
     click.echo(f"Annotating depths file...")
-    annotate_depths(annotation, depths, json_file)
+    annotate_depths(annotation, depths, json_file, input_csv)
 
 if __name__ == '__main__':
     main()

--- a/modules/local/annotatedepth/main.nf
+++ b/modules/local/annotatedepth/main.nf
@@ -13,6 +13,7 @@ process ANNOTATE_DEPTHS {
     tuple val(meta) , path(depths)
     tuple val(meta2), path(panel_all)
     path (json_groups)
+    path (input_csv)
 
     output:
     // tuple val(meta), path("*.depths.annotated.tsv.gz") , emit: annotated_depths
@@ -32,7 +33,8 @@ process ANNOTATE_DEPTHS {
     merge_annotation_depths.py \\
         --annotation ${panel_all}.contexts \\
         --depths ${depths} \\
-        --json_file ${json_groups}
+        --json_file ${json_groups} \\
+        --input_csv ${input_csv}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -207,7 +207,7 @@ workflow DEEPCSA{
     CREATEPANELS(DEPTHANALYSIS.out.depths, vep_cache, vep_extra_files)
     ch_versions = ch_versions.mix(CREATEPANELS.out.versions)
 
-    ANNOTATEDEPTHS(DEPTHANALYSIS.out.depths, CREATEPANELS.out.all_panel, TABLE2GROUP.out.json_allgroups)
+    ANNOTATEDEPTHS(DEPTHANALYSIS.out.depths, CREATEPANELS.out.all_panel, TABLE2GROUP.out.json_allgroups, file(params.input))
     ch_versions = ch_versions.mix(ANNOTATEDEPTHS.out.versions)
     ANNOTATEDEPTHS.out.annotated_depths.flatten().map{ it -> [ [id : it.name.tokenize('.')[0]] , it]  }.set{ annotated_depths }
 


### PR DESCRIPTION
### My summary
Update previous version of the script that was doing the postprocessing of the compute depths command to make sure it takes into account the sample names provided by the user enabling the customization of the deepCSA sample names without forcing to change the BAM files filename, even if these must also be different from each other to ensure the possibility to tell them apart from one another.


#### GitHub Copilot summary

This pull request includes changes to the `ANNOTATE_DEPTHS` process in the `modules/local/annotatedepth/main.nf` file and the `DEEPCSA` workflow in the `workflows/deepcsa.nf` file. These changes primarily introduce a new input parameter and modify the corresponding commands to handle this new input.

Changes to `ANNOTATE_DEPTHS` process:

* Added `input_csv` as a new input parameter.
* Updated the `merge_annotation_depths.py` command to include the `--input_csv` option.

Changes to `DEEPCSA` workflow:

* Modified the `ANNOTATEDEPTHS` process call to include the new `file(params.input)` parameter.