### PR TITLE
New mutation density calculation: closes #272

### DIFF
--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -85,7 +85,7 @@ def mutation_density(sample_name, depths_file, somatic_mutations_file, mutabilit
             # compute vector of sum of depths per trinucleotide context
 
             region_df = panel_df[(panel_df['IMPACT'].isin(csqn_set)) & (panel_df['GENE'] == gene)].copy()
-            dh = pd.merge(region_df[['CHROM', 'POS']], depth_df[['CHROM', 'POS', 'CONTEXT', sample]], on=['CHROM', 'POS'], how='left')
+            dh = pd.merge(region_df[['CHROM', 'POS']], depths_df[['CHROM', 'POS', 'CONTEXT', sample]], on=['CHROM', 'POS'], how='left')
             depth_sum_df = dh.groupby(by='CONTEXT').agg({sample: 'sum'}).reset_index()
             depth_region_dict = dict(zip(depth_sum_df['CONTEXT'], depth_sum_df[sample]))
             depth_region_vect = np.array([depth_region_dict.get(k[:3], 0) for k in triplet_contexts])

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -3,6 +3,8 @@
 import click
 import pandas as pd
 import numpy as np
+
+import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 
 

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -85,9 +85,9 @@ def mutation_density(sample_name, depths_file, somatic_mutations_file, mutabilit
             # compute vector of sum of depths per trinucleotide context
 
             region_df = panel_df[(panel_df['IMPACT'].isin(csqn_set)) & (panel_df['GENE'] == gene)].copy()
-            dh = pd.merge(region_df[['CHROM', 'POS']], depths_df[['CHROM', 'POS', 'CONTEXT', sample]], on=['CHROM', 'POS'], how='left')
-            depth_sum_df = dh.groupby(by='CONTEXT').agg({sample: 'sum'}).reset_index()
-            depth_region_dict = dict(zip(depth_sum_df['CONTEXT'], depth_sum_df[sample]))
+            dh = pd.merge(region_df[['CHROM', 'POS']], depths_df[['CHROM', 'POS', 'CONTEXT', sample_name]], on=['CHROM', 'POS'], how='left')
+            depth_sum_df = dh.groupby(by='CONTEXT').agg({sample_name: 'sum'}).reset_index()
+            depth_region_dict = dict(zip(depth_sum_df['CONTEXT'], depth_sum_df[sample_name]))
             depth_region_vect = np.array([depth_region_dict.get(k[:3], 0) for k in triplet_contexts])
 
             # compute correction factor "alpha hat"

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -121,7 +121,7 @@ def mutation_density(sample_name, depths_file, somatic_mutations_file, mutabilit
 @click.option('--mutability_file', type=click.Path(exists=True), help='Relative mutability per trinucleotide context')
 @click.option('--panel_file', type=click.Path(exists=True), help='All possible SNVs with csqn type')
 @click.option('--trinucleotide_counts_file', type=click.Path(exists=True), help='How many trinucleotides of each type are in the entire genome')
-def main(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file, output_file):
+def main(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file):
 
     click.echo(f"Running the mutability adjusted mutation density estimation...")
     res = mutation_density(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file)

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -38,7 +38,7 @@ triplet_contexts = list(triplet_context_iterator())
 # The following function computes the normalization factor so that the mutation density
 # matches the equivalent to 1 mut/(Mb-genome) on average across the mappable genome.
 
-def get_correction_factor(trinucleotide_counts_df, mutability_df, flat=False):
+def get_correction_factor(sample_name, trinucleotide_counts_df, mutability_df, flat=False):
 
     # vector of triplet count in 96-channel canonical sorting
 
@@ -55,7 +55,7 @@ def get_correction_factor(trinucleotide_counts_df, mutability_df, flat=False):
     if flat:
         relative_mutability = (1 / 96) * np.ones(96)
     else:
-        d = dict(zip(mutability_df['CONTEXT_MUT'], mutability_df[f'{sample}.all']))
+        d = dict(zip(mutability_df['CONTEXT_MUT'], mutability_df[f'{sample_name}.all']))
         relative_mutability = np.array([d.get(k, 0) for k in triplet_contexts])
 
     # return correction factor a.k.a. "alpha hat"
@@ -92,7 +92,7 @@ def mutation_density(sample_name, depths_file, somatic_mutations_file, mutabilit
 
             # compute correction factor "alpha hat"
 
-            correction_factor, relative_mutability = get_correction_factor(trinucleotide_counts_df, mutability_df)
+            correction_factor, relative_mutability = get_correction_factor(sample_name, trinucleotide_counts_df, mutability_df)
 
             # compute effective length
 

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -125,7 +125,7 @@ def main(sample_name, depths_file, somatic_mutations_file, mutability_file, pane
 
     click.echo(f"Running the mutability adjusted mutation density estimation...")
     res = mutation_density(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file)
-    res.to_csv(f'{sample_name}.mutdensities.tsv', sep='\t', index=False)
+    res.to_csv(f'{sample_name}.mutdensities.tsv', sep='\t')
 
 
 if __name__ == '__main__':

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -8,54 +8,34 @@ import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 import seaborn as sns
 
-
-# Consequence type ontology
-
-broadimpact_grouping_dict = { 
-    "missense": ["missense"], 
-    "nonsense": ["nonsense"], 
-    "essential_splice": ["essential_splice"], 
-    "splice_region_variant": ["splice_region_variant"], 
-    "truncating": ["nonsense", "essential_splice"], 
-    "essential_splice_plus": ["essential_splice", "splice_region_variant"], 
-    "truncating_plus": ["nonsense", "essential_splice", "splice_region_variant"], 
-    "nonsynonymous_splice": ["missense", "nonsense", "essential_splice"],
-    "synonymous": ["synonymous"]
-    } 
+from utils_context import triplet_context_iterator
+from utils_impacts import broadimpact_grouping_dict_with_synonymous
 
 
 # Utils
-
-def triplet_context_iterator():
-    subs = ['C>A', 'C>G', 'C>T', 'T>A', 'T>C', 'T>G']
-    flanks = ['AA', 'AC', 'AG', 'AT', 'CA', 'CC', 'CG', 'CT',
-              'GA', 'GC', 'GG', 'GT', 'TA', 'TC', 'TG', 'TT']
-    for sub in subs:
-        for flank in flanks:
-            yield flank[0] + sub[0] + flank[1] + '>' + sub[-1]
-
-
 # define canonical order for trinucleotide contexts
 
-triplet_contexts = list(triplet_context_iterator())
+triplet_contexts = triplet_context_iterator()
 
-# The following function computes the normalization factor so that the mutation density
-# matches the equivalent to 1 mut/(Mb-genome) on average across the mappable genome.
 
 def get_correction_factor(sample_name, trinucleotide_counts_df, mutability_df, flat=False):
+    """
+    The following function computes the normalization factor so that the mutation density
+        that we will compute downstream matches the equivalent to 1 mut/(Mb-genome)
+        on average across the genome.
+    
+    More specifically here
+    """
 
     # vector of triplet count in 96-channel canonical sorting
-
     triplet_counts_dict = dict(zip(trinucleotide_counts_df['CONTEXT'].values, trinucleotide_counts_df['COUNT'].values))
     l = [triplet_counts_dict[c[:3]] for c in triplet_contexts]
     triplet_counts = np.array(l)
 
     # genome length in Mb
-
-    genome_length = sum(triplet_counts) / (3 * 1e6)
+    genome_length = (sum(triplet_counts) / 3) * 1e6
 
     # vector of relative mutabilities in 96-channel canonical sorting
-    
     if flat:
         relative_mutability = (1 / 96) * np.ones(96)
     else:
@@ -63,7 +43,6 @@ def get_correction_factor(sample_name, trinucleotide_counts_df, mutability_df, f
         relative_mutability = np.array([d.get(k, 0) for k in triplet_contexts])
 
     # return correction factor a.k.a. "alpha hat"
-
     correction_factor = genome_length / np.dot(relative_mutability, triplet_counts)
     
     return correction_factor, relative_mutability
@@ -78,30 +57,34 @@ def mutation_density(sample_name, depths_file, somatic_mutations_file, mutabilit
     trinucleotide_counts_df = pd.read_csv(trinucleotide_counts_file, sep='\t')
 
     genes = panel_df['GENE'].unique()
-    consequences = broadimpact_grouping_dict.keys()
+    consequences = broadimpact_grouping_dict_with_synonymous.keys()
 
     res = pd.DataFrame(index=genes, columns=consequences)
 
-    for csqn, csqn_set in broadimpact_grouping_dict.items():
+    for csqn, csqn_set in broadimpact_grouping_dict_with_synonymous.items():
         
         for gene in panel_df['GENE'].unique():
             
             # compute vector of sum of depths per trinucleotide context
-
+            # tailored to the specific gene-impact target
             region_df = panel_df[(panel_df['IMPACT'].isin(csqn_set)) & (panel_df['GENE'] == gene)].copy()
-            dh = pd.merge(region_df[['CHROM', 'POS']], depths_df[['CHROM', 'POS', 'CONTEXT', sample_name]], on=['CHROM', 'POS'], how='left')
+
+            # counting every position once
+            dh = pd.merge(region_df[['CHROM', 'POS']],
+                          depths_df[['CHROM', 'POS', 'CONTEXT', sample_name]],
+                          on=['CHROM', 'POS'], how='left')
             depth_sum_df = dh.groupby(by='CONTEXT').agg({sample_name: 'sum'}).reset_index()
             depth_region_dict = dict(zip(depth_sum_df['CONTEXT'], depth_sum_df[sample_name]))
             depth_region_vect = np.array([depth_region_dict.get(k[:3], 0) for k in triplet_contexts])
 
-            # compute correction factor "alpha hat"
 
+            # compute correction factor "alpha hat"
             correction_factor, relative_mutability = get_correction_factor(sample_name, trinucleotide_counts_df, mutability_df, flat=flat)
 
-            # compute effective length
 
+            # compute effective length
             effective_length = correction_factor * np.dot(relative_mutability, depth_region_vect)
-            
+
             try:
                 assert(effective_length != 0)
             except AssertionError:
@@ -110,7 +93,7 @@ def mutation_density(sample_name, depths_file, somatic_mutations_file, mutabilit
             
             # observed somatic mutations
 
-            n = somatic_mutations_df[(somatic_mutations_df['canonical_Consequence_broader'].isin(csqn_set)) & (somatic_mutations_df['SYMBOL'] == gene) & ((somatic_mutations_df['TYPE'] == 'SNV'))].shape[0]
+            n = somatic_mutations_df[(somatic_mutations_df['IMPACT'].isin(csqn_set)) & (somatic_mutations_df['GENE'] == gene)].shape[0]
 
             res.loc[gene, csqn] = n / effective_length
     
@@ -168,6 +151,7 @@ def main(sample_name, depths_file, somatic_mutations_file, mutability_file, pane
     
     # save results
     res.to_csv(f'{sample_name}.mutdensities.tsv', sep='\t')
+    res_flat.to_csv(f'{sample_name}.mutdensities_flat.tsv', sep='\t')
     logfoldchange_plot(sample_name, res, res_flat)
 
 

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -151,6 +151,8 @@ def main(sample_name, depths_file, somatic_mutations_file, mutability_file, pane
     # save results
     res["SAMPLE"] = sample_name
     res_flat["SAMPLE"] = sample_name
+    res.index.name = 'GENE'
+    res_flat.index.name = 'GENE'
     res[['SAMPLE'] + [col for col in res.columns if col != 'SAMPLE']].to_csv(f'{sample_name}.mutdensities.tsv', sep='\t')
     res_flat[['SAMPLE'] + [col for col in res_flat.columns if col != 'SAMPLE']].to_csv(f'{sample_name}.mutdensities_flat.tsv', sep='\t')
 

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -146,11 +146,14 @@ def main(sample_name, depths_file, somatic_mutations_file, mutability_file, pane
     # main calculations
     res = mutation_density(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file, flat=False)
     res_flat = mutation_density(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file, flat=True)
-    
-    # save results
-    res.to_csv(f'{sample_name}.mutdensities.tsv', sep='\t')
-    res_flat.to_csv(f'{sample_name}.mutdensities_flat.tsv', sep='\t')
     logfoldchange_plot(sample_name, res, res_flat)
+
+    # save results
+    res["SAMPLE"] = sample_name
+    res_flat["SAMPLE"] = sample_name
+    res[['SAMPLE'] + [col for col in res.columns if col != 'SAMPLE']].to_csv(f'{sample_name}.mutdensities.tsv', sep='\t')
+    res_flat[['SAMPLE'] + [col for col in res_flat.columns if col != 'SAMPLE']].to_csv(f'{sample_name}.mutdensities_flat.tsv', sep='\t')
+
 
 
 if __name__ == '__main__':

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -23,8 +23,6 @@ def get_correction_factor(sample_name, trinucleotide_counts_df, mutability_df, f
     The following function computes the normalization factor so that the mutation density
         that we will compute downstream matches the equivalent to 1 mut/(Mb-genome)
         on average across the genome.
-    
-    More specifically here
     """
 
     # vector of triplet count in 96-channel canonical sorting
@@ -33,7 +31,7 @@ def get_correction_factor(sample_name, trinucleotide_counts_df, mutability_df, f
     triplet_counts = np.array(l)
 
     # genome length in Mb
-    genome_length = (sum(triplet_counts) / 3) * 1e6
+    genome_length = sum(triplet_counts) / (3 * 1e6)
 
     # vector of relative mutabilities in 96-channel canonical sorting
     if flat:

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -114,7 +114,7 @@ def mutation_density(sample_name, depths_file, somatic_mutations_file, mutabilit
     return res
 
 
-def logfoldchange_plot(df, df_flat, output_file):
+def logfoldchange_plot(sample_name, df, df_flat):
     """
     Heatmap representing log-FC between mutability adjusted and flat mutation density.
     This can be useful as a diagnostic tool of the mutation density calculation.
@@ -122,7 +122,7 @@ def logfoldchange_plot(df, df_flat, output_file):
 
     dh = (df + 0.01) / (df_flat + 0.01)  # Include a pseudocount
     dh = np.log2(dh.astype(float))
-    with PdfPages(output_file) as pdf:
+    with PdfPages(f'{sample_name}.logfoldchangeplot.pdf') as pdf:
 
         plt.figure(figsize=(8, 6)) # Set the size of the plot
         sns.heatmap(
@@ -138,7 +138,7 @@ def logfoldchange_plot(df, df_flat, output_file):
         )
 
         # Set the title and labels
-        plt.title(f'{sample}\nlog2 fold-change mutability adjusted vs flat', fontsize=16)
+        plt.title(f'{sample_name}\nlog2 fold-change mutability adjusted vs flat', fontsize=16)
         plt.xticks(rotation=45, ha='right')
         plt.yticks(rotation=0)
 
@@ -165,7 +165,7 @@ def main(sample_name, depths_file, somatic_mutations_file, mutability_file, pane
     
     # save results
     res.to_csv(f'{sample_name}.mutdensities.tsv', sep='\t')
-    logfoldchange_plot(res, res_flat, f'{sample}.logfoldchangeplot.pdf')
+    logfoldchange_plot(sample_name, res, res_flat)
 
 
 if __name__ == '__main__':

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import click
 import pandas as pd
 import numpy as np

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
+import seaborn as sns
 
 
 # Consequence type ontology

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -125,7 +125,7 @@ def main(sample_name, depths_file, somatic_mutations_file, mutability_file, pane
 
     click.echo(f"Running the mutability adjusted mutation density estimation...")
     res = mutation_density(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file)
-    res.to_csv(f'{sample_name}.mut_density.tsv', sep='\t', index=False)
+    res.to_csv(f'{sample_name}.mutdensities.tsv', sep='\t', index=False)
 
 
 if __name__ == '__main__':

--- a/bin/mut_density.py
+++ b/bin/mut_density.py
@@ -1,0 +1,130 @@
+import click
+import pandas as pd
+import numpy as np
+
+
+# Consequence type ontology
+
+broadimpact_grouping_dict = { 
+    "missense": ["missense"], 
+    "nonsense": ["nonsense"], 
+    "essential_splice": ["essential_splice"], 
+    "splice_region_variant": ["splice_region_variant"], 
+    "truncating": ["nonsense", "essential_splice"], 
+    "essential_splice_plus": ["essential_splice", "splice_region_variant"], 
+    "truncating_plus": ["nonsense", "essential_splice", "splice_region_variant"], 
+    "nonsynonymous_splice": ["missense", "nonsense", "essential_splice"],
+    "synonymous": ["synonymous"]
+    } 
+
+
+# Utils
+
+def triplet_context_iterator():
+    subs = ['C>A', 'C>G', 'C>T', 'T>A', 'T>C', 'T>G']
+    flanks = ['AA', 'AC', 'AG', 'AT', 'CA', 'CC', 'CG', 'CT',
+              'GA', 'GC', 'GG', 'GT', 'TA', 'TC', 'TG', 'TT']
+    for sub in subs:
+        for flank in flanks:
+            yield flank[0] + sub[0] + flank[1] + '>' + sub[-1]
+
+
+# define canonical order for trinucleotide contexts
+
+triplet_contexts = list(triplet_context_iterator())
+
+# The following function computes the normalization factor so that the mutation density
+# matches the equivalent to 1 mut/(Mb-genome) on average across the mappable genome.
+
+def get_correction_factor(trinucleotide_counts_df, mutability_df, flat=False):
+
+    # vector of triplet count in 96-channel canonical sorting
+
+    triplet_counts_dict = dict(zip(trinucleotide_counts_df['CONTEXT'].values, trinucleotide_counts_df['COUNT'].values))
+    l = [triplet_counts_dict[c[:3]] for c in triplet_contexts]
+    triplet_counts = np.array(l)
+
+    # genome length in Mb
+
+    genome_length = sum(triplet_counts) / (3 * 1e6)
+
+    # vector of relative mutabilities in 96-channel canonical sorting
+    
+    if flat:
+        relative_mutability = (1 / 96) * np.ones(96)
+    else:
+        d = dict(zip(mutability_df['CONTEXT_MUT'], mutability_df[f'{sample}.all']))
+        relative_mutability = np.array([d.get(k, 0) for k in triplet_contexts])
+
+    # return correction factor a.k.a. "alpha hat"
+
+    correction_factor = genome_length / np.dot(relative_mutability, triplet_counts)
+    
+    return correction_factor, relative_mutability
+
+
+def mutation_density(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file):
+
+    depths_df = pd.read_csv(depths_file, sep='\t')
+    somatic_mutations_df = pd.read_csv(somatic_mutations_file, sep='\t')
+    mutability_df = pd.read_csv(mutability_file, sep='\t')
+    panel_df = pd.read_csv(panel_file, sep='\t')
+    trinucleotide_counts_df = pd.read_csv(trinucleotide_counts_file, sep='\t')
+
+    genes = panel_df['GENE'].unique()
+    consequences = broadimpact_grouping_dict.keys()
+
+    res = pd.DataFrame(index=genes, columns=consequences)
+
+    for csqn, csqn_set in broadimpact_grouping_dict.items():
+        
+        for gene in panel_df['GENE'].unique():
+            
+            # compute vector of sum of depths per trinucleotide context
+
+            region_df = panel_df[(panel_df['IMPACT'].isin(csqn_set)) & (panel_df['GENE'] == gene)].copy()
+            dh = pd.merge(region_df[['CHROM', 'POS']], depth_df[['CHROM', 'POS', 'CONTEXT', sample]], on=['CHROM', 'POS'], how='left')
+            depth_sum_df = dh.groupby(by='CONTEXT').agg({sample: 'sum'}).reset_index()
+            depth_region_dict = dict(zip(depth_sum_df['CONTEXT'], depth_sum_df[sample]))
+            depth_region_vect = np.array([depth_region_dict.get(k[:3], 0) for k in triplet_contexts])
+
+            # compute correction factor "alpha hat"
+
+            correction_factor, relative_mutability = get_correction_factor(trinucleotide_counts_df, mutability_df)
+
+            # compute effective length
+
+            effective_length = correction_factor * np.dot(relative_mutability, depth_region_vect)
+            
+            try:
+                assert(effective_length != 0)
+            except AssertionError:
+                res.loc[gene, csqn] = None
+                continue
+            
+            # observed somatic mutations
+
+            n = somatic_mutations_df[(somatic_mutations_df['canonical_Consequence_broader'].isin(csqn_set)) & (somatic_mutations_df['SYMBOL'] == gene) & ((somatic_mutations_df['TYPE'] == 'SNV'))].shape[0]
+
+            res.loc[gene, csqn] = n / effective_length
+    
+    return res
+
+
+
+@click.command()
+@click.option('--sample_name', type=str, help='Name of the sample being processed.')
+@click.option('--depths_file', type=str, help='Depth per position in panel')
+@click.option('--somatic_mutations_file', type=click.Path(exists=True), help='Observed somatic mutations')
+@click.option('--mutability_file', type=click.Path(exists=True), help='Relative mutability per trinucleotide context')
+@click.option('--panel_file', type=click.Path(exists=True), help='All possible SNVs with csqn type')
+@click.option('--trinucleotide_counts_file', type=click.Path(exists=True), help='How many trinucleotides of each type are in the entire genome')
+def main(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file, output_file):
+
+    click.echo(f"Running the mutability adjusted mutation density estimation...")
+    res = mutation_density(sample_name, depths_file, somatic_mutations_file, mutability_file, panel_file, trinucleotide_counts_file)
+    res.to_csv(f'{sample_name}.mut_density.tsv', sep='\t', index=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/utils_context.py
+++ b/bin/utils_context.py
@@ -15,6 +15,20 @@ def canonical_channels():
     return sorted_contexts
 
 
+def triplet_context_iterator():
+    subs = ['C>A', 'C>G', 'C>T', 'T>A', 'T>C', 'T>G']
+    flanks = ['AA', 'AC', 'AG', 'AT', 'CA', 'CC', 'CG', 'CT',
+              'GA', 'GC', 'GG', 'GT', 'TA', 'TC', 'TG', 'TT']
+    contexts = []
+    for sub in subs:
+        for flank in flanks:
+            contexts.append( flank[0] + sub[0] + flank[1] + '>' + sub[-1])
+
+    return contexts
+    
+
+
+
 def transform_context(chr_, pos, mut, assembly = hg38):
     # TODO remove this try-except
     try:

--- a/bin/utils_impacts.py
+++ b/bin/utils_impacts.py
@@ -238,3 +238,16 @@ broadimpact_grouping_dict = {
         "truncating_plus": ["nonsense", "essential_splice", "splice_region_variant"],
         "nonsynonymous_splice": ["missense", "nonsense", "essential_splice"]
     }
+
+
+broadimpact_grouping_dict_with_synonymous = {
+        "missense": ["missense"],
+        "nonsense": ["nonsense"],
+        "essential_splice": ["essential_splice"],
+        "splice_region_variant": ["splice_region_variant"],
+        "truncating": ["nonsense", "essential_splice"],
+        "essential_splice_plus": ["essential_splice", "splice_region_variant"],
+        "truncating_plus": ["nonsense", "essential_splice", "splice_region_variant"],
+        "nonsynonymous_splice": ["missense", "nonsense", "essential_splice"],
+        "synonymous": ["synonymous"]
+    }

--- a/conf/tools/mutdensity.config
+++ b/conf/tools/mutdensity.config
@@ -27,11 +27,11 @@ process {
     }
 
     withName: 'SUBSETMUTDENSITYADJUSTED' {
-        ext.filters     = ''
+        ext.filters     = { ['"TYPE": "SNV"'].join(',\t').trim()}
 
         ext.output_fmt  = { ['"header": true',
                                 '"columns": ["SAMPLE_ID",  "MUT_ID", "ALT_DEPTH", "canonical_SYMBOL", "canonical_Consequence_broader", "TYPE"]',
-                                '"colnames": ["SAMPLE_ID", "MUT_ID", "ALT_DEPTH", "SYMBOL", "canonical_Consequence_broader", "TYPE"]'
+                                '"colnames": ["SAMPLE_ID", "MUT_ID", "ALT_DEPTH", "GENE", "IMPACT", "TYPE"]'
                             ].join(',\t').trim()
                         }
 

--- a/conf/tools/mutdensity.config
+++ b/conf/tools/mutdensity.config
@@ -26,6 +26,20 @@ process {
         ]
     }
 
+    withName: 'SUBSETMUTDENSITYADJUSTED' {
+        ext.filters     = ''
+
+        ext.output_fmt  = { ['"header": true',
+                                '"columns": ["SAMPLE_ID",  "MUT_ID", "ALT_DEPTH", "canonical_SYMBOL", "canonical_Consequence_broader", "TYPE"]',
+                                '"colnames": ["SAMPLE_ID", "MUT_ID", "ALT_DEPTH", "SYMBOL", "canonical_Consequence_broader", "TYPE"]'
+                            ].join(',\t').trim()
+                        }
+
+        publishDir       = [
+                enabled : false
+        ]
+    }
+
     withName: 'BBGTOOLS:DEEPCSA:MUTDENSITYPROT:SUBSETMUTDENSITY' {
         ext.filters     = { ['"Protein_affecting": "protein_affecting"'].join(',\t').trim()
                         }

--- a/modules/local/mut_density/main.nf
+++ b/modules/local/mut_density/main.nf
@@ -12,8 +12,9 @@ process MUTATION_DENSITY {
 
 
     output:
-    tuple val(meta), path("*.mutdensities.tsv") ,        emit: mutdensities
-    path "versions.yml" ,                                topic: versions
+    tuple val(meta), path("*.mutdensities.tsv") ,    emit: mutdensities
+    path("*.logfoldchangeplot.pdf") ,                emit: mutdensities_plots
+    path "versions.yml" ,                            topic: versions
 
     script:
     def sample_name = "${meta.id}"
@@ -37,6 +38,7 @@ process MUTATION_DENSITY {
     def prefix = task.ext.prefix ?: "all_samples"
     """
     touch ${prefix}.mutdensities.tsv
+    touch ${prefix}.logfoldchangeplot.pdf
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/mut_density/main.nf
+++ b/modules/local/mut_density/main.nf
@@ -8,12 +8,12 @@ process MUTATION_DENSITY {
     input:
     tuple val(meta), path(somatic_mutations_file), path(depths_file), path(mutability_file)
     tuple val(meta2), path(panel_file)
-    tuple val(meta3), path(trinucleotide_counts_file)
+    path(trinucleotide_counts_file)
 
 
     output:
     tuple val(meta), path("*.mutdensities.tsv") ,        emit: mutdensities
-    path "versions.yml" ,                               topic: versions
+    path "versions.yml" ,                                topic: versions
 
     script:
     def sample_name = "${meta.id}"

--- a/modules/local/mut_density/main.nf
+++ b/modules/local/mut_density/main.nf
@@ -12,13 +12,13 @@ process MUTATION_DENSITY {
 
 
     output:
-    tuple val(meta), path("*.mutdensities.tsv") ,    emit: mutdensities
-    path("*.logfoldchangeplot.pdf") ,                emit: mutdensities_plots
+    tuple val(meta), path("*.mutdensities.tsv")         , emit: mutdensities
+    tuple val(meta), path("*.mutdensities_flat.tsv")    , emit: mutdensities_flat   
+    path("*.logfoldchangeplot.pdf")                     , emit: mutdensities_plots
     path "versions.yml" ,                            topic: versions
 
     script:
     def sample_name = "${meta.id}"
-    def panel_version = task.ext.panel_version ?: "${meta2.id}"
     """
     mut_density.py \\
                         --sample_name ${sample_name} \\

--- a/modules/local/mut_density/main.nf
+++ b/modules/local/mut_density/main.nf
@@ -1,0 +1,47 @@
+process MUTATION_DENSITY {
+
+    tag "$meta.id"
+    label 'process_high'
+
+    container "docker.io/bbglab/deepcsa-core:0.0.1-alpha"
+
+    input:
+    tuple val(meta), path(somatic_mutations_file), path(depths_file), path(mutability_file)
+    tuple val(meta2), path(panel_file)
+    tuple val(meta3), path(trinucleotide_counts_file)
+
+
+    output:
+    tuple val(meta), path("*.mutdensities.tsv") ,        emit: mut_density_results
+    path "versions.yml" ,                               topic: versions
+
+    script:
+    def sample_name = "${meta.id}"
+    def panel_version = task.ext.panel_version ?: "${meta2.id}"
+    """
+    mut_density.py \\
+                        --sample_name ${sample_name} \\
+                        --depths_file ${depths_file} \\
+                        --somatic_mutations_file ${somatic_mutations_file} \\
+                        --mutability_file ${mutability_file} \\
+                        --panel_file ${panel_file} \\
+                        --trinucleotide_counts_file ${trinucleotide_counts_file}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "all_samples"
+    def panel_version = task.ext.panel_version ?: "${meta2.id}"
+    """
+    touch ${prefix}.${panel_version}.mutdensities.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/modules/local/mut_density/main.nf
+++ b/modules/local/mut_density/main.nf
@@ -35,9 +35,8 @@ process MUTATION_DENSITY {
 
     stub:
     def prefix = task.ext.prefix ?: "all_samples"
-    def panel_version = task.ext.panel_version ?: "${meta2.id}"
     """
-    touch ${prefix}.${panel_version}.mutdensities.tsv
+    touch ${prefix}.mutdensities.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/mut_density/main.nf
+++ b/modules/local/mut_density/main.nf
@@ -12,7 +12,7 @@ process MUTATION_DENSITY {
 
 
     output:
-    tuple val(meta), path("*.mutdensities.tsv") ,        emit: mut_density_results
+    tuple val(meta), path("*.mutdensities.tsv") ,        emit: mutdensities
     path "versions.yml" ,                               topic: versions
 
     script:

--- a/subworkflows/local/mut_density/main.nf
+++ b/subworkflows/local/mut_density/main.nf
@@ -31,4 +31,5 @@ workflow MUTATION_DENSITY{
 
     emit:
     mutdensities = MUTDENSITY.out.mutdensities
+    mutdensities_plots = MUTDENSITY.out.mutdensities_plots
 }

--- a/subworkflows/local/mut_density/main.nf
+++ b/subworkflows/local/mut_density/main.nf
@@ -2,8 +2,6 @@ include { TABIX_BGZIPTABIX_QUERY    as SUBSETMUTATIONS  } from '../../../modules
 
 include { SUBSET_MAF                as SUBSETMUTDENSITYADJUSTED   } from '../../../modules/local/subsetmaf/main'
 
-// include { MUTATION_DENSITY          as MUTDENSITY_FLAT  } from '../../../modules/local/computemutdensity/main'
-
 include { MUTATION_DENSITY          as MUTDENSITY       } from '../../../modules/local/mut_density/main'
 
 

--- a/subworkflows/local/mut_density/main.nf
+++ b/subworkflows/local/mut_density/main.nf
@@ -1,0 +1,36 @@
+include { TABIX_BGZIPTABIX_QUERY    as SUBSETMUTATIONS  } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
+
+include { SUBSET_MAF                as SUBSETMUTDENSITYADJUSTED   } from '../../../modules/local/subsetmaf/main'
+
+// include { MUTATION_DENSITY          as MUTDENSITY_FLAT  } from '../../../modules/local/computemutdensity/main'
+
+include { MUTATION_DENSITY          as MUTDENSITY       } from '../../../modules/local/mut_density/main'
+
+
+workflow MUTATION_DENSITY{
+    take:
+    mutations
+    depth
+    bedfile
+    panel
+    mutability_file
+    trinucleotide_counts
+
+    main:
+
+    // Intersect BED of all sites with BED of sample filtered sites
+    SUBSETMUTATIONS(mutations, bedfile)
+
+    SUBSETMUTDENSITYADJUSTED(SUBSETMUTATIONS.out.subset)
+
+    SUBSETMUTDENSITYADJUSTED.out.mutations
+    .join(depth)
+    .join(mutability_file)
+    .set{ mutations_n_depth_n_profile }
+
+    MUTDENSITY(mutations_n_depth_n_profile, panel, trinucleotide_counts)
+
+
+    emit:
+    mutdensities = MUTDENSITY.out.mutdensities
+}

--- a/subworkflows/local/mut_density/main.nf
+++ b/subworkflows/local/mut_density/main.nf
@@ -30,6 +30,7 @@ workflow MUTATION_DENSITY{
 
 
     emit:
-    mutdensities = MUTDENSITY.out.mutdensities
-    mutdensities_plots = MUTDENSITY.out.mutdensities_plots
+    mutdensities        = MUTDENSITY.out.mutdensities
+    mutdensities_flat   = MUTDENSITY.out.mutdensities_flat
+    mutdensities_plots  = MUTDENSITY.out.mutdensities_plots
 }

--- a/subworkflows/local/mut_density/main.nf
+++ b/subworkflows/local/mut_density/main.nf
@@ -1,8 +1,8 @@
-include { TABIX_BGZIPTABIX_QUERY    as SUBSETMUTATIONS  } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
+include { TABIX_BGZIPTABIX_QUERY    as SUBSETMUTATIONS          } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
 
-include { SUBSET_MAF                as SUBSETMUTDENSITYADJUSTED   } from '../../../modules/local/subsetmaf/main'
+include { SUBSET_MAF                as SUBSETMUTDENSITYADJUSTED } from '../../../modules/local/subsetmaf/main'
 
-include { MUTATION_DENSITY          as MUTDENSITY       } from '../../../modules/local/mut_density/main'
+include { MUTATION_DENSITY          as MUTDENSITYADJ            } from '../../../modules/local/mut_density/main'
 
 
 workflow MUTATION_DENSITY{
@@ -26,11 +26,11 @@ workflow MUTATION_DENSITY{
     .join(mutability_file)
     .set{ mutations_n_depth_n_profile }
 
-    MUTDENSITY(mutations_n_depth_n_profile, panel, trinucleotide_counts)
+    MUTDENSITYADJ(mutations_n_depth_n_profile, panel, trinucleotide_counts)
 
 
     emit:
-    mutdensities        = MUTDENSITY.out.mutdensities
-    mutdensities_flat   = MUTDENSITY.out.mutdensities_flat
-    mutdensities_plots  = MUTDENSITY.out.mutdensities_plots
+    mutdensities        = MUTDENSITYADJ.out.mutdensities
+    mutdensities_flat   = MUTDENSITYADJ.out.mutdensities_flat
+    mutdensities_plots  = MUTDENSITYADJ.out.mutdensities_plots
 }

--- a/subworkflows/local/mutationdensity/main.nf
+++ b/subworkflows/local/mutationdensity/main.nf
@@ -1,8 +1,8 @@
 include { TABIX_BGZIPTABIX_QUERY    as SUBSETMUTATIONS      } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
 
-include { SUBSET_MAF                as SUBSETMUTDENSITY        } from '../../../modules/local/subsetmaf/main'
+include { SUBSET_MAF                as SUBSETMUTDENSITY     } from '../../../modules/local/subsetmaf/main'
 
-include { MUTATION_DENSITY          as MUTDENSITYFLAT           } from '../../../modules/local/computemutdensity/main'
+include { MUTATION_DENSITY          as MUTDENSITY           } from '../../../modules/local/computemutdensity/main'
 
 
 workflow MUTATION_DENSITY{
@@ -23,9 +23,9 @@ workflow MUTATION_DENSITY{
     .join(depth)
     .set{ mutations_n_depth }
 
-    MUTDENSITYFLAT(mutations_n_depth, panel)
+    MUTDENSITY(mutations_n_depth, panel)
 
 
     emit:
-    mutdensities = MUTDENSITYFLAT.out.mutdensities
+    mutdensities = MUTDENSITY.out.mutdensities
 }

--- a/subworkflows/local/mutationdensity/main.nf
+++ b/subworkflows/local/mutationdensity/main.nf
@@ -2,7 +2,7 @@ include { TABIX_BGZIPTABIX_QUERY    as SUBSETMUTATIONS      } from '../../../mod
 
 include { SUBSET_MAF                as SUBSETMUTDENSITY        } from '../../../modules/local/subsetmaf/main'
 
-include { MUTATION_DENSITY          as MUTDENSITY           } from '../../../modules/local/computemutdensity/main'
+include { MUTATION_DENSITY          as MUTDENSITYFLAT           } from '../../../modules/local/computemutdensity/main'
 
 
 workflow MUTATION_DENSITY{
@@ -23,9 +23,9 @@ workflow MUTATION_DENSITY{
     .join(depth)
     .set{ mutations_n_depth }
 
-    MUTDENSITY(mutations_n_depth, panel)
+    MUTDENSITYFLAT(mutations_n_depth, panel)
 
 
     emit:
-    mutdensities = MUTDENSITY.out.mutdensities
+    mutdensities = MUTDENSITYFLAT.out.mutdensities
 }

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -263,7 +263,7 @@ workflow DEEPCSA{
         .concat(MUTDENSITYNONPROT.out.mutdensities.map{ it -> it[1]}.flatten())
         .concat(MUTDENSITYSYNONYMOUS.out.mutdensities.map{ it -> it[1]}.flatten())
         .set{ all_mutdensities }
-        all_mutdensities.collectFile(name: "all_mutdensities.tsv", storeDir:"${params.outdir}/mutdensityflat", skip: 1, keepHeader: true).set{ all_mutdensities_file }
+        all_mutdensities.collectFile(name: "all_mutdensities.tsv", storeDir:"${params.outdir}/mutdensity", skip: 1, keepHeader: true).set{ all_mutdensities_file }
 
     }
 
@@ -277,11 +277,11 @@ workflow DEEPCSA{
             // Concatenate all outputs into a single file
             MUTDENSITYADJUSTED.out.mutdensities.map{ it -> it[1]}.flatten()
             .set{ all_adjusted_mutdensities }
-            all_adjusted_mutdensities.collectFile(name: "all_adjusted_mutdensities.tsv", storeDir:"${params.outdir}/mutdensity", skip: 1, keepHeader: true)
+            all_adjusted_mutdensities.collectFile(name: "all_adjusted_mutdensities.tsv", storeDir:"${params.outdir}/mutdensityadj", skip: 1, keepHeader: true)
 
             MUTDENSITYADJUSTED.out.mutdensities_flat.map{ it -> it[1]}.flatten()
             .set{ all_adjusted_mutdensities_flat }
-            all_adjusted_mutdensities_flat.collectFile(name: "all_adjusted_mutdensities_flat.tsv", storeDir:"${params.outdir}/mutdensity", skip: 1, keepHeader: true)
+            all_adjusted_mutdensities_flat.collectFile(name: "all_adjusted_mutdensities_flat.tsv", storeDir:"${params.outdir}/mutdensityadj", skip: 1, keepHeader: true)
         }
     }
     if (params.profilenonprot){

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -271,7 +271,7 @@ workflow DEEPCSA{
     // Mutational profile
     if (params.profileall){
         MUTPROFILEALL(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.all_consensus_bed, wgs_trinucs)
-        MUTDENSITYADJUSTED(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.all_consensus_bed, CREATEPANELS.out.all_consensus_panel, MUTPROFILEALL.out.profile, wgs_trinucs)
+        MUTDENSITYADJUSTED(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.exons_consensus_bed, CREATEPANELS.out.exons_consensus_panel, MUTPROFILEALL.out.profile, wgs_trinucs)
 
     }
     if (params.profilenonprot){

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -271,8 +271,18 @@ workflow DEEPCSA{
     // Mutational profile
     if (params.profileall){
         MUTPROFILEALL(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.all_consensus_bed, wgs_trinucs)
-        MUTDENSITYADJUSTED(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.exons_consensus_bed, CREATEPANELS.out.exons_consensus_panel, MUTPROFILEALL.out.profile, wgs_trinucs)
+        if (run_mutdensity){
+            MUTDENSITYADJUSTED(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.exons_consensus_bed, CREATEPANELS.out.exons_consensus_panel, MUTPROFILEALL.out.profile, wgs_trinucs)
 
+            // Concatenate all outputs into a single file
+            MUTDENSITYADJUSTED.out.mutdensities.map{ it -> it[1]}.flatten()
+            .set{ all_adjusted_mutdensities }
+            all_adjusted_mutdensities.collectFile(name: "all_adjusted_mutdensities.tsv", storeDir:"${params.outdir}/mutdensity", skip: 1, keepHeader: true)
+
+            MUTDENSITYADJUSTED.out.mutdensities_flat.map{ it -> it[1]}.flatten()
+            .set{ all_adjusted_mutdensities_flat }
+            all_adjusted_mutdensities_flat.collectFile(name: "all_adjusted_mutdensities_flat.tsv", storeDir:"${params.outdir}/mutdensity", skip: 1, keepHeader: true)
+        }
     }
     if (params.profilenonprot){
         MUTPROFILENONPROT(somatic_mutations, DEPTHSNONPROTCONS.out.subset, CREATEPANELS.out.nonprot_consensus_bed, wgs_trinucs)
@@ -284,7 +294,6 @@ workflow DEEPCSA{
         DEPTHSINTRONSCONS(annotated_depths, CREATEPANELS.out.introns_consensus_bed)
         MUTPROFILEINTRONS(somatic_mutations, DEPTHSINTRONSCONS.out.subset, CREATEPANELS.out.introns_consensus_bed, wgs_trinucs)
     }
-
 
 
     if (run_mutabilities) {


### PR DESCRIPTION
Calculation of mutation density adjusted for the trinucleotide-context-specific mutabilities (mutability-adjusted, for short) at the set of predefined consequence types discussed in #272. The calculation produces two types of outputs:

* dataframes: file name of the form `$OUTPUT/mutdensity/<sample_id>.mutdenisities.tsv`, comprising the mutation density values for each gene and consequence type;
* heatmap plots: file name of the form `$OUTPUT/mutdensity/<sample_id>.logfoldchangeplot.pdf`, representing the log2 fold change of the mutability-adjusted mutation density vs the flat mutation density where each trinucleotide is assumed to have the same mutability.

This PR should be considered a first usable version subject to minimal testing with which we can start to survey more broadly across all cohorts and samples. Possible adjustments in future versions may include:

* Expanding the consequence type definitions
* New running options or configs: user-defined collections of sites, user-defined regions, non-coding regions, non-coding consequence types, user-defined mutability profiles.

Ways in which this new feature may be used to improve other features of the pipeline:

* Using the synonymous mutation density to improve the so-called globalloc background mutagenesis estimate employed by the omega method.