### PR TITLE
Update feature groups input definition

### DIFF
--- a/bin/features_1table2groups.py
+++ b/bin/features_1table2groups.py
@@ -31,7 +31,8 @@ def main(table_filename, separator, unique_identifier, groups):
 
     groups_of_interest = []
     for comparison in groups_of_interest_init:
-        comparison_group = [item for item in comparison if item != '']
+        comparison_group_clean = [item.strip() for item in comparison]
+        comparison_group = [item for item in comparison_group_clean if item != '']
         if len(comparison_group) > 0:
             groups_of_interest.append(comparison_group)
 

--- a/bin/features_1table2groups.py
+++ b/bin/features_1table2groups.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 
-import sys
+import click
 import pandas as pd
 import json
 from read_utils import custom_na_values
-
-table_filename = sys.argv[1]
-separator_input = sys.argv[2] # either tab or comma
-json_information = sys.argv[3]
 
 separator2character = {
     'tab' : '\t',
@@ -18,67 +14,66 @@ def reformatnames(name):
     return str(name).lower().replace(' ','').replace('_','').replace('.','').capitalize()
 
 
-separator = separator2character.get(separator_input, separator_input)
+@click.command()
+@click.option('--table-filename', required=True, type=click.Path(exists=True), help='Input features table file')
+@click.option('--separator', required=True, type=click.Choice(['tab', 'comma']), help='Separator: tab or comma')
+@click.option('--unique-identifier', default=None, type=str, help='Unique identifier column name')
+@click.option('--groups', default=None, type=str, help='List of columns with grouping information')
+def main(table_filename, separator, unique_identifier, groups):
 
-features_table = pd.read_table(table_filename, header = 0, sep=separator, na_values = custom_na_values)
+    sep_char = separator2character[separator]
+    features_table = pd.read_table(table_filename, header=0, sep=sep_char, na_values=custom_na_values)
 
+    uniq_name = unique_identifier if unique_identifier else "sample"
 
-with open(json_information, 'r') as file:
-    dict_of_columns = json.load(file)
+    # groups may contain lists of lists, but all formatted into a string
+    groups_of_interest_init = [group.strip().strip(",").split(",") for group in groups.replace("[", ";;;").replace("]", "").split(";;;")] if groups else []
 
-if len(dict_of_columns) > 0:
-    uniq_name = dict_of_columns['unique_identifier']
-    groups_of_interest = dict_of_columns['groups_of_interest']
-else:
-    uniq_name = "sample"
     groups_of_interest = []
+    for comparison in groups_of_interest_init:
+        comparison_group = [item for item in comparison if item != '']
+        if len(comparison_group) > 0:
+            groups_of_interest.append(comparison_group)
 
-samples_json = { str(name) : [str(name)] for name in features_table[uniq_name] }
+    print(f"Unique identifier: {uniq_name}")
+    print(f"Groups of interest: ")
+    for group in groups_of_interest:
+        print(f"{group}", type(group))
 
-json_groups = {}
+    samples_json = { str(name) : [str(name)] for name in features_table[uniq_name] }
+    json_groups = {}
 
+    for col_names2group in groups_of_interest:
+        dict_sample_groups = features_table.groupby(by=col_names2group).agg({uniq_name : list}).reset_index().to_dict()
+        for category in list(dict_sample_groups[uniq_name].keys()):
+            dict_sample_groups[uniq_name][category] = [ str(x) for x in dict_sample_groups[uniq_name][category] ]
+        for i in dict_sample_groups[col_names2group[0]].keys():
+            sample_batch_name = ""
+            for cat in col_names2group:
+                formatted_category = reformatnames(cat)
+                value_of_variable = dict_sample_groups[cat][i]
+                if type(value_of_variable) == bool:
+                    sample_batch_name += f"{formatted_category}{ 'Yes' if value_of_variable else 'No'}_"
+                else:
+                    sample_batch_name += f"{formatted_category}{reformatnames(dict_sample_groups[cat][i])}_"
+            sample_batch_name = sample_batch_name.strip("_")
+            json_groups[sample_batch_name] = dict_sample_groups[uniq_name][i]
 
+    # Write samples json
+    with open("samples.json", "w") as outfile:
+        json.dump(samples_json, outfile)
 
-for col_names2group in groups_of_interest:
+    if len(json_groups) > 0:
+        # Write groups json
+        with open("groups.json", "w") as outfile:
+            json.dump(json_groups, outfile)
 
-    dict_sample_groups = features_table.groupby(by = col_names2group).agg({uniq_name : list}).reset_index().to_dict()
-    for category in list(dict_sample_groups[uniq_name].keys()):
-        dict_sample_groups[uniq_name][category] = [ str(x) for x in dict_sample_groups[uniq_name][category] ]
-
-    for i in dict_sample_groups[col_names2group[0]].keys():
-        sample_batch_name = ""
-        for cat in col_names2group:
-            formatted_category = reformatnames(cat)
-            value_of_variable = dict_sample_groups[cat][i]
-            if type(value_of_variable) == bool:
-                sample_batch_name += f"{formatted_category}{ 'Yes' if value_of_variable else 'No'}_"
-
-            # TODO consider adding an option to categorize numerical variables
-
-            else:
-                sample_batch_name += f"{formatted_category}{reformatnames(dict_sample_groups[cat][i])}_"
-
-        sample_batch_name = sample_batch_name.strip("_")
-        # print(sample_batch_name, len(dict_sample_groups[uniq_name][i]), dict_sample_groups[uniq_name][i])
-        json_groups[sample_batch_name] = dict_sample_groups[uniq_name][i]
-    # print()
-
-# Write samples json
-with open("samples.json", "w") as outfile:
-    json.dump(samples_json, outfile)
-
-
-if len(json_groups) > 0:
-    # Write groups json
-    with open("groups.json", "w") as outfile:
+    # Write all samples and groups json
+    json_groups.update(samples_json)
+    json_groups["all_samples"] = [str(x) for x in samples_json.keys()]
+    with open("all_groups.json", "w") as outfile:
         json.dump(json_groups, outfile)
 
 
-# Write all samples and groups json
-json_groups.update(samples_json)
-
-json_groups["all_samples"] = [str(x) for x in samples_json.keys()]
-with open("all_groups.json", "w") as outfile:
-    json.dump(json_groups, outfile)
-
-
+if __name__ == '__main__':
+    main()

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -300,7 +300,7 @@ process {
 
     withName: "TABLE2GROUP" {
         ext.unique_identifier   = params.features_unique_identifier
-        ext.feature_groups      = params.features_groups_lists
+        ext.feature_groups      = params.features_groups_list
         ext.separator           = params.features_table_separator
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -299,8 +299,9 @@ process {
 
 
     withName: "TABLE2GROUP" {
-        ext.features       = params.features_table_dict
-        ext.separator      = params.features_table_separator
+        ext.unique_identifier   = params.features_unique_identifier
+        ext.feature_groups      = params.features_groups_lists
+        ext.separator           = params.features_table_separator
     }
 
     withName: "GROUPGENES" {

--- a/conf/test_real.config
+++ b/conf/test_real.config
@@ -21,9 +21,9 @@ params {
 
     features_table           = "/data/bbg/datasets/transfer/ferriol_deepcsa/test/small_cohort_bladder.tsv"
     features_table_separator =  'tab'
-    features_table_dict      =  ['"unique_identifier" : "SAMPLE_ID"',
-                                    '"groups_of_interest" : [ ["BLADDER_LOCATION"], ["BLADDER_LOCATION", "SEX"], ["BLADDER_LOCATION", "SEX", "SMOKING_STATUS"] ]'
-                                    ].join(',\t').trim()
+    features_unique_identifier               = "SAMPLE_ID"
+    features_groups_list                     = '[ ["BLADDER_LOCATION"], ["BLADDER_LOCATION", "SEX"], ["BLADDER_LOCATION", "SEX", "SMOKING_STATUS"] ]'
+
 
     use_custom_minimum_depth    = 10
 

--- a/modules/local/table2groups/main.nf
+++ b/modules/local/table2groups/main.nf
@@ -14,20 +14,16 @@ process TABLE_2_GROUP {
     path("all_groups.json")                     , emit: json_allgroups
     path "versions.yml"                         , topic: versions
 
-
     script:
     def separator = task.ext.separator ?: "comma"
-    def features = task.ext.features ?: ""
-    // TODO reimplement with click
+    def custom_groups = task.ext.feature_groups ? "--groups ${task.ext.feature_groups}" : ""
+    def unique_identifier = task.ext.unique_identifier ? "--unique-identifier ${task.ext.unique_identifier}" : ""
     """
-    cat > features_table_information.json << EOF
-    {
-        ${features}
-    }
-    EOF
-
-    features_1table2groups.py ${features_table} ${separator} features_table_information.json
-
+    features_1table2groups.py \\
+                --table-filename ${features_table} \\
+                --separator ${separator} \\
+                ${unique_identifier} \\
+                ${custom_groups}
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')

--- a/modules/local/table2groups/main.nf
+++ b/modules/local/table2groups/main.nf
@@ -16,7 +16,7 @@ process TABLE_2_GROUP {
 
     script:
     def separator = task.ext.separator ?: "comma"
-    def custom_groups = task.ext.feature_groups ? "--groups ${task.ext.feature_groups}" : ""
+    def custom_groups = task.ext.feature_groups ? "--groups \"${task.ext.feature_groups}\" " : ""
     def unique_identifier = task.ext.unique_identifier ? "--unique-identifier ${task.ext.unique_identifier}" : ""
     """
     features_1table2groups.py \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,7 +15,8 @@ params {
 
     features_table                           = null
     features_table_separator                 = 'comma'
-    features_table_dict                      = ''
+    features_groups_list                     = null
+    features_unique_identifier               = null
 
     custom_groups                            = false
     custom_groups_file                       = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -94,9 +94,15 @@
                     "help_text": "",
                     "fa_icon": "far fa-file-code"
                 },
-                "features_table_dict": {
+                "features_groups_list": {
                     "type": "string",
-                    "description": "String in JSON-like format defining the groups of samples.",
+                    "description": "String in list format defining the variables that have to be used for grouping samples.",
+                    "help_text": "This is required when the features_table dataset wants to be used.",
+                    "fa_icon": "far fa-file-code"
+                },
+                "features_unique_identifier": {
+                    "type": "string",
+                    "description": "String defining the column with the unique identifier in the features_table that should include all the names of the samples that want to be used for the analysis.",
                     "help_text": "This is required when the features_table dataset wants to be used.",
                     "fa_icon": "far fa-file-code"
                 }


### PR DESCRIPTION
Input definition for the features to use for grouping variants has brought some problems.

Reimplementing the input handling with click allowed for a simple solution splitting the two main elements into two arguments

## AI summary
This pull request refactors how feature grouping parameters are handled for the `TABLE_2_GROUP` process, moving from a single dictionary-style parameter to more explicit and structured parameters for unique identifiers and groups. This improves clarity, maintainability, and aligns parameter handling across configuration, schema, and process logic.

**Parameter and schema refactoring:**

* Replaced the single `features_table_dict` parameter with two explicit parameters: `features_unique_identifier` and `features_groups_list` in `nextflow.config`, `test_real.config`, and `nextflow_schema.json`, providing clearer descriptions and requirements for each. [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL18-R19) [[2]](diffhunk://#diff-e26f99cdc232094fe4af0c52752c5ef9f0fd2896ca7a1e8fe4d2ea71589edcbeL24-R26) [[3]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6L97-R105)
* Updated the `modules.config` to pass the new explicit parameters (`features_unique_identifier` and `features_groups_list`) to the `TABLE2GROUP` process, replacing the previous dictionary-based approach.

**Process logic improvements:**

* Refactored the `TABLE_2_GROUP` process in `main.nf` to use the new parameters, updating the script to pass them as command-line arguments to `features_1table2groups.py` instead of generating a JSON file from a dictionary.