### PR TITLE
Allow the option to plot selection and saturation at the level of groups

### DIFF
--- a/bin/features_1table2groups.py
+++ b/bin/features_1table2groups.py
@@ -64,14 +64,14 @@ def main(table_filename, separator, unique_identifier, groups):
     with open("samples.json", "w") as outfile:
         json.dump(samples_json, outfile)
 
-    if len(json_groups) > 0:
-        # Write groups json
-        with open("groups.json", "w") as outfile:
-            json.dump(json_groups, outfile)
+    json_groups["all_samples"] = [str(x) for x in samples_json.keys()]
+
+    # Write groups json
+    with open("groups.json", "w") as outfile:
+        json.dump(json_groups, outfile)
 
     # Write all samples and groups json
     json_groups.update(samples_json)
-    json_groups["all_samples"] = [str(x) for x in samples_json.keys()]
     with open("all_groups.json", "w") as outfile:
         json.dump(json_groups, outfile)
 

--- a/bin/plot_gene_saturation.py
+++ b/bin/plot_gene_saturation.py
@@ -1241,10 +1241,10 @@ def plotting_wrapper(maf, exons_depth, o3d_df, exon_selection, domain_selection,
         # and the formatting of domain selection can be done only once
         df, gene_color_dict = format_domain_selection(domain_selection, xshift=0.22)
         df = df.copy()[:60]
-        plot_all_domain_selection(df, gene_color_dict, figsize=(16,6), save=True, filename=f"{output_directory}/domain_selection.missense_truncating.pdf")
+        plot_all_domain_selection(df, gene_color_dict, figsize=(16,6), save=True, filename=f"{output_directory}/domain_selection.missense_truncating.png")
         for impact in ["missense", "truncating"]:
             df, gene_color_dict = format_domain_selection(domain_selection[domain_selection["impact"] == impact], sort_by=impact, xshift=0)[:60]
-            plot_all_domain_selection(df, gene_color_dict, figsize=(14,6), save=True, filename=f"{output_directory}/domain_selection.{impact}.pdf")
+            plot_all_domain_selection(df, gene_color_dict, figsize=(14,6), save=True, filename=f"{output_directory}/domain_selection.{impact}.png")
 
     except Exception as e:
         print(f"Plots for domain selection at cohort level did not work.")

--- a/modules/local/plot/saturation/main.nf
+++ b/modules/local/plot/saturation/main.nf
@@ -6,14 +6,13 @@ process PLOT_SATURATION {
     container "docker.io/bbglab/deepcsa-core:0.0.2-alpha"
 
     input:
-    tuple val(meta) , path(results_files)
+    tuple val(meta) , path(results_files)  // includes all positive selection results and site comparisons
     tuple val(meta2), path(all_samples_indv_depths)
-    tuple val(meta3), path(site_selection_files)
-    tuple val(meta4), path(panel_file)
+    tuple val(meta3), path(panel_file)
     path (gene_data_df)
     path (pdb_df)
     path (domains_df)
-    tuple val(meta5), path (exons_depths_df)
+    tuple val(meta4), path (exons_depths_df)
 
     output:
     tuple val(meta), path("**.png")  , emit: plots

--- a/modules/local/plot/saturation/main.nf
+++ b/modules/local/plot/saturation/main.nf
@@ -6,7 +6,7 @@ process PLOT_SATURATION {
     container "docker.io/bbglab/deepcsa-core:0.0.2-alpha"
 
     input:
-    tuple val(meta) , path(results_files)  // includes all positive selection results and site comparisons
+    tuple val(meta) , path(results_files) , path(site_comparison) // includes all positive selection results and site comparisons
     tuple val(meta2), path(all_samples_indv_depths)
     tuple val(meta3), path(panel_file)
     path (gene_data_df)

--- a/nextflow.config
+++ b/nextflow.config
@@ -74,6 +74,7 @@ params {
 
     signatures                               = false
 
+    plot_only_allsamples                     = true
 
     confidence_level                         = 'med'
     pileup_all_duplex                        = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -368,6 +368,13 @@
                     "type": "boolean",
                     "description": "Do you want to run regression analysis?",
                     "fa_icon": "fas fa-book"
+                },
+                "plot_only_allsamples": {
+                    "type": "boolean",
+                    "description": "Do you want to generate summary plots only for the entire cohort (true) or also include the specific subgroups created (false)?",
+                    "fa_icon": "fas fa-book",
+                    "default": true,
+                    "help_text": "Do you want to generate summary plots only for the entire cohort (true) or also include the specific subgroups created (false)?"
                 }
             }
         },

--- a/subworkflows/local/plottingsummary/main.nf
+++ b/subworkflows/local/plottingsummary/main.nf
@@ -51,7 +51,7 @@ workflow PLOTTING_SUMMARY {
     groups_results
     .join( site_comparison )
     .set{ groups_results_sites }
-    
+
     PLOTSELECTION(groups_results, seqinfo_df)
     // needles with consequence type
     // plot selection at cohort/group level, all the different methods available

--- a/subworkflows/local/plottingsummary/main.nf
+++ b/subworkflows/local/plottingsummary/main.nf
@@ -21,6 +21,7 @@ workflow PLOTTING_SUMMARY {
     seqinfo_df
     domain_df
     exons_depths_df
+    groups_channel
 
 
     main:
@@ -33,21 +34,30 @@ workflow PLOTTING_SUMMARY {
     // PLOTNEEDLES(muts_all_samples, sequence_information_df)
 
 
-    // plotting only for the entire cohort group
-    Channel.of([ [ id: "all_samples" ] ])
-    .join( positive_selection_results_ready )
-    .set{ all_samples_results }
+    if ( params.plot_only_allsamples ) {
+        // plotting only for the entire cohort group
+        Channel.of([ [ id: "all_samples" ] ])
+        .join( positive_selection_results_ready )
+        .set{ groups_results }
+    } else {
+        // plotting for all groups
+        positive_selection_results_ready
+        .map { mut -> tuple(mut[0].id, mut) }
+        .join(groups_channel)
+        .map { it[1] }
+        .set { groups_results }
+    }
 
-    PLOTSELECTION(all_samples_results, seqinfo_df)
+    groups_results
+    .join( site_comparison )
+    .set{ groups_results_sites }
+    
+    PLOTSELECTION(groups_results, seqinfo_df)
     // needles with consequence type
     // plot selection at cohort/group level, all the different methods available
     // plot selection per domain at cohort level
 
-    Channel.of([ [ id: "all_samples" ] ])
-    .join( site_comparison )
-    .set{ all_samples_sites }
-
-    PLOTSATURATION(all_samples_results, all_samples_depth, all_samples_sites, panel, seqinfo_df, pdb_tool_df, domain_df, exons_depths_df)
+    PLOTSATURATION(groups_results_sites, all_samples_depth, panel, seqinfo_df, pdb_tool_df, domain_df, exons_depths_df)
     // plot gene + site selection
     // omega selection per domain in gene
     // ? plot saturation kinetics curves

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -183,6 +183,13 @@ workflow DEEPCSA{
 
     TABLE2GROUP(features_table)
 
+    // Load group keys from JSON file in 'groups' channel
+    def group_keys = TABLE2GROUP.out.json_groups.map { json_path ->
+        def json = file(json_path).text
+        groovy.json.JsonSlurper.newInstance().parseText(json).keySet()
+    }.flatten().unique()
+    .set { group_keys_ch } // this is a channel that contains only the group names as elements of the channel
+
 
     // Depths and panel creation should be a single subworkflow
     // Depth analysis: compute and plots
@@ -211,6 +218,7 @@ workflow DEEPCSA{
                         CREATEPANELS.out.all_consensus_bed,
                         CREATEPANELS.out.exons_bed,
                         TABLE2GROUP.out.json_allgroups,
+                        group_keys_ch,
                         seqinfo_df,
                         CREATEPANELS.out.added_custom_regions
                         )
@@ -543,7 +551,8 @@ workflow DEEPCSA{
                         CREATEPANELS.out.panel_annotated_rich,
                         seqinfo_df,
                         CREATEPANELS.out.domains_in_panel,
-                        DNA2PROTEINMAPPING.out.depths_exons_positions
+                        DNA2PROTEINMAPPING.out.depths_exons_positions,
+                        group_keys_ch
                         )
     }    
     

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -542,16 +542,16 @@ workflow DEEPCSA{
     if ( params.omega & params.oncodrive3d & params.oncodrivefml & params.indels  & (params.vep_species == 'homo_sapiens') ){
         positive_selection_results_ready = positive_selection_results.map { element -> [element[0], element[1..-1]] }
         PLOTTINGSUMMARY(positive_selection_results_ready,
-                        all_mutdensities_file,
+                        all_mutdensities_file.first(),
                         site_comparison_results,
-                        ANNOTATEDEPTHS.out.all_samples_depths,
-                        TABLE2GROUP.out.json_samples,
-                        TABLE2GROUP.out.json_allgroups,
+                        ANNOTATEDEPTHS.out.all_samples_depths.first(),
+                        TABLE2GROUP.out.json_samples.first(),
+                        TABLE2GROUP.out.json_allgroups.first(),
                         CREATEPANELS.out.exons_consensus_panel,
                         CREATEPANELS.out.panel_annotated_rich,
                         seqinfo_df,
-                        CREATEPANELS.out.domains_in_panel,
-                        DNA2PROTEINMAPPING.out.depths_exons_positions,
+                        CREATEPANELS.out.domains_in_panel.first(),
+                        DNA2PROTEINMAPPING.out.depths_exons_positions.first(),
                         group_keys_ch
                         )
     }    


### PR DESCRIPTION
* Add variable to control plotting for groups

## AI summary
This pull request introduces changes to improve the flexibility and accuracy of plotting and group management in the workflow, especially for summary plots and mutation preprocessing. The main updates include the addition of a new parameter to control plot generation for cohorts vs. subgroups, refactoring of input channels to better handle group information, and improved filtering and joining logic for plotting modules.

**Plotting configuration and logic improvements:**

* Added a new parameter `plot_only_allsamples` to both `nextflow.config` and `nextflow_schema.json`, allowing users to specify whether to generate summary plots only for the entire cohort or also for subgroups. The plotting logic in `subworkflows/local/plottingsummary/main.nf` now uses this parameter to determine which groups to plot. [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaR77) [[2]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6R371-R377) [[3]](diffhunk://#diff-f7fe245a8b6d973068ceed613f4d5813b08e66e9e6c2a89079eb9fe3ffdf3427R37-R60)
* Refactored the `PLOTSATURATION` process input in `modules/local/plot/saturation/main.nf` to include `site_comparison` results, and streamlined input tuple handling for clarity and correctness.

**Group and channel management enhancements:**

* Introduced a new `groups_channel` input and improved group key extraction in `workflows/deepcsa.nf` to ensure channels contain only group names, supporting more robust joining and filtering in downstream modules. [[1]](diffhunk://#diff-87c636ed11c630b436dd28dc585de64022c0bbf406a7875587e2598a5a0c9cb5R186-R192) [[2]](diffhunk://#diff-87c636ed11c630b436dd28dc585de64022c0bbf406a7875587e2598a5a0c9cb5R221) [[3]](diffhunk://#diff-87c636ed11c630b436dd28dc585de64022c0bbf406a7875587e2598a5a0c9cb5L537-R555)
* Updated mutation preprocessing workflow in `subworkflows/local/mutationpreprocessing/main.nf` to use `all_groups` instead of `groups` for writing MAF files, and improved filtering of mutations for plotting by joining with group keys. [[1]](diffhunk://#diff-8b998b9dc22991dcdd3aec5090036335ccd7d57fd001b9fd6a7cbd0d243f8e97R29) [[2]](diffhunk://#diff-8b998b9dc22991dcdd3aec5090036335ccd7d57fd001b9fd6a7cbd0d243f8e97L73-R74) [[3]](diffhunk://#diff-8b998b9dc22991dcdd3aec5090036335ccd7d57fd001b9fd6a7cbd0d243f8e97L115-R123)

**General workflow consistency:**

* Updated input and output channel handling throughout plotting and preprocessing workflows to ensure consistent use of first elements and correct joining/filtering by group, improving reproducibility and clarity. [[1]](diffhunk://#diff-87c636ed11c630b436dd28dc585de64022c0bbf406a7875587e2598a5a0c9cb5L537-R555) [[2]](diffhunk://#diff-f7fe245a8b6d973068ceed613f4d5813b08e66e9e6c2a89079eb9fe3ffdf3427R24)

These changes collectively improve the modularity and configurability of the workflow, making it easier to control plotting behavior and ensuring accurate group-based analyses.