### PR TITLE
fix bug in redefinition of panel with subgenic elements

### DIFF
--- a/bin/add_hotspots.py
+++ b/bin/add_hotspots.py
@@ -51,8 +51,39 @@ def main(panel_file, autoexons, autodomains, custom):
                 print("Updating chromosome to:", current_chr)
 
             # Get start and end indices
-            ind_start = np.where(chr_data["POS"] == row["START"])[0][0]
-            ind_end = np.where(chr_data.iloc[ind_start:,:]["POS"] == row["END"])[0][0]
+            start_matches = np.where(chr_data["POS"] == row["START"])[0]
+            start_found = len(start_matches) > 0
+            if start_found:
+                ind_start = start_matches[0]
+            else:
+                # Use the first position greater than or equal to START, or the last if none
+                start_matches = np.where(chr_data["POS"] >= row["START"])[0]
+                if len(start_matches) > 0:
+                    ind_start = start_matches[0]
+                    start_found = True
+                else:
+                    print("No start match for row:", row)
+                    continue
+
+            # If you reach ths point, ind_start is defined and valid
+            # Search for END position starting from ind_start
+            search_end = chr_data.iloc[ind_start:,:]
+            end_matches = np.where(search_end["POS"] == row["END"])[0]
+
+            end_found = len(end_matches) > 0
+            if end_found:
+                ind_end = end_matches[0]
+            else:
+                # Use the last position less than or equal to END, or the last available
+                end_matches = np.where(search_end["POS"] <= row["END"])[-1]
+                if len(end_matches) > 0:
+                    ind_end = end_matches[-1]
+                    end_found = True
+                else:
+                    print("No end match found for row:", row)
+                    continue
+
+            # if you reach this point, start and end are defined and valid
             gene = chr_data.iloc[ind_start]["GENE"]
 
             ind_end += ind_start

--- a/bin/add_hotspots.py
+++ b/bin/add_hotspots.py
@@ -72,7 +72,7 @@ def main(panel_file, autoexons, autodomains, custom):
 
             end_found = len(end_matches) > 0
             if end_found:
-                ind_end = end_matches[0]
+                ind_end = end_matches[-1]
             else:
                 # Use the last position less than or equal to END, or the last available
                 end_matches = np.where(search_end["POS"] <= row["END"])[-1]

--- a/conf/general_files_IRB.config
+++ b/conf/general_files_IRB.config
@@ -6,9 +6,7 @@ params {
     // Fasta references
     fasta                 = '/data/bbg/datasets/genomes/GRCh38/clean_n_fixed_genome/GCA_000001405.15_GRCh38_no_alt_analysis_set.masked.fna'
 
-    wgs_trinuc_counts     = "assets/trinucleotide_counts/trinuc_counts.homo_sapiens.tsv"
-
-    cosmic_ref_signatures = "/data/bbg/datasets/transfer/ferriol_deepcsa/COSMIC_v3.4_SBS_GRCh38.txt"
+    cosmic_ref_signatures = "/data/bbg/datasets/COSMIC_signatures/COSMIC_v3.4_SBS_GRCh38.txt"
     wgs_trinuc_counts     = "/data/bbg/datasets/transfer/ferriol_deepcsa/trinucleotide_counts/trinuc_counts.homo_sapiens.tsv"
     cadd_scores           = "/data/bbg/datasets/CADD/v1.7/hg38/whole_genome_SNVs.tsv.gz"
     cadd_scores_ind       = "/data/bbg/datasets/CADD/v1.7/hg38/whole_genome_SNVs.tsv.gz.tbi"

--- a/docs/issue_resolution.md
+++ b/docs/issue_resolution.md
@@ -7,9 +7,10 @@ This document provides an overview of the issues identified during the developme
 ## Table of Contents
 
 1. [BedTools merge: 0-len interval wrongly merged](#issue-1)
-2. [Issue 2: Description of the issue](#issue-2)
-3. [Issue 3: Description of the issue](#issue-3)
-4. ...
+2. [Addition of pseudocount to fill the mutational profile](#issue-2)
+3. [Incomplete coverage of subgenic element raises error in expanded panel building](#issue-3)
+4. [Issue 4: Description of the issue](#issue-4)
+5. ...
 
 ## 1. BedTools merge: 0-len interval wrongly merged  <a name="issue-1"></a>
 
@@ -82,7 +83,25 @@ Specifically add one third of the smallest non-zero value of the normalized prof
 
 
 
-## 3. Issue 3: Description of the issue <a name="issue-3"></a>
+## 3. Incomplete coverage of subgenic element raises error in expanded panel building <a name="issue-3"></a>
+
+This becomes a problem when subgenic elements that are not fully covered by the consensus exons panel are excluded from the resulting expanded regions file.
+
+### Processes affected:
+- `EXPANDREGIONS`
+
+
+### GitHub tracking
+
+- **GitHub Issue:** [Link to GitHub Issue](https://github.com/bbglab/deepCSA/issues/363)
+- **GitHub PR (Resolution):** [Link to GitHub PR](https://github.com/bbglab/deepCSA/issues/373)
+
+### Resolution <a name="resolution"></a>
+
+The solution is that even if a region is partially covered include those covered areas in the expanded panel that is created. This ensures the full representation of all the elements in the downstream analysis, but does not guarantee the full comparison between runs since different groups of samples might result in different panel definitions and then potentially different subgenic-regions definition.
+
+
+## 4. Issue 3: Description of the issue <a name="issue-4"></a>
 
 Description of the issue, including its impact and context.
 

--- a/docs/issue_resolution.md
+++ b/docs/issue_resolution.md
@@ -94,14 +94,14 @@ This becomes a problem when subgenic elements that are not fully covered by the 
 ### GitHub tracking
 
 - **GitHub Issue:** [Link to GitHub Issue](https://github.com/bbglab/deepCSA/issues/363)
-- **GitHub PR (Resolution):** [Link to GitHub PR](https://github.com/bbglab/deepCSA/issues/373)
+- **GitHub PR (Resolution):** [Link to GitHub PR](https://github.com/bbglab/deepCSA/pull/373)
 
 ### Resolution <a name="resolution"></a>
 
-The solution is that even if a region is partially covered include those covered areas in the expanded panel that is created. This ensures the full representation of all the elements in the downstream analysis, but does not guarantee the full comparison between runs since different groups of samples might result in different panel definitions and then potentially different subgenic-regions definition.
+The solution is to include the covered portions of a region in the expanded panel even if the region is only partially covered. This ensures representation of all elements in downstream analyses, but it does not guarantee full comparability between runs because different sample groups may yield different panel and subgenic-region definitions.
 
 
-## 4. Issue 3: Description of the issue <a name="issue-4"></a>
+## 4. Issue 4: Description of the issue <a name="issue-4"></a>
 
 Description of the issue, including its impact and context.
 


### PR DESCRIPTION
- now if a subgenic element is partially covered, it is still included in the expanded file, before it was not 

Properly documented in the issue resolution section in the docs 

## AI summary
This pull request updates the reference paths for the COSMIC signatures and trinucleotide counts in the `conf/general_files_IRB.config` file. The main change is to ensure that the configuration points to the correct and most up-to-date data files.

Configuration updates:

* Updated the `cosmic_ref_signatures` path to use the new COSMIC signatures directory.
* Updated the `wgs_trinuc_counts` path to reflect the new location within the `transfer/ferriol_deepcsa/trinucleotide_counts` directory.