### PR TITLE
Add mutdensity QCs per group

### DIFF
--- a/bin/mutation_densities_qc.py
+++ b/bin/mutation_densities_qc.py
@@ -69,7 +69,15 @@ def z_score_log10(mutden_df, mode = 'per_sample') :
 
 # Function to plot results from z-score distribution
 
-def plt_violin_omega_qc(mutdensity_zscore_df, mode = 'per_gene', zero_cases_flag = None):
+def plt_violin_omega_qc(mutdensity_zscore_df, mode = 'per_gene', zero_cases_flag = None, min_points = 3):
+    
+    # If the dataset is too small to produce meaningful plots (e.g. a single
+    # sample/group), skip plotting and return None. The caller in `main` already
+    # handles a None return (it will continue to the next loop iteration).
+    if mutdensity_zscore_df is None or len(mutdensity_zscore_df) < min_points:
+        n = 0 if mutdensity_zscore_df is None else len(mutdensity_zscore_df)
+        print(f"Skipping plotting: dataset too small (n={n})")
+        return None
     
     # Setup subplots
     fig, axes = plt.subplots(1, 2, figsize=(12, 7), sharey=False)
@@ -128,7 +136,7 @@ def plt_violin_omega_qc(mutdensity_zscore_df, mode = 'per_gene', zero_cases_flag
                  va='center', ha='left', wrap=True)
 
     # Main title
-    plt.suptitle(f'{mode} - {mutdensity_zscore_df['REGIONS'].iloc[0]}', fontsize=14)
+    plt.suptitle(f'{mode} - {mutdensity_zscore_df["REGIONS"].iloc[0]}', fontsize=14)
     plt.tight_layout(rect=[0, 0.03, 0.92, 0.95])  # leave space for side text
     
     return(fig)
@@ -147,7 +155,7 @@ def plt_violin_omega_qc(mutdensity_zscore_df, mode = 'per_gene', zero_cases_flag
 @click.option("--group-name", required=True, type=str,
               help="Name of the group to be analyzed")
 
-def main(input_file, output_dir, panel, groups_definition, group_name): 
+def main(input_file, output_dir, panel, group_definition, group_name): 
 
     mutden_df = pd.read_table(input_file, sep='\t')
     panel = pd.read_table(panel)
@@ -155,7 +163,7 @@ def main(input_file, output_dir, panel, groups_definition, group_name):
     panel_genes_init = panel['GENE'].unique().tolist()
     del panel
 
-    sample_names = load_samples_names(groups_definition, group_name)
+    sample_names = load_samples_names(group_definition, group_name)
 
     ## 1. Initial general filtering by panel genes
     panel_genes = panel_genes_init + ['ALL_GENES'] # is this an issue for the per_gene omega?

--- a/modules/local/plot/qc/mutation_densities/main.nf
+++ b/modules/local/plot/qc/mutation_densities/main.nf
@@ -8,8 +8,8 @@ process PLOT_MUTDENSITY_QC {
     input:
     path(all_mutdensities)
     tuple val(meta2), path(panel_file)
-
-    path (samples_json)
+    path (groups_json)
+    val (group_name)
 
     output:
     path("**.pdf")  , emit: plots
@@ -19,15 +19,15 @@ process PLOT_MUTDENSITY_QC {
 
 
     script:
-    def prefix = task.ext.prefix ?: "all_samples"
 
     """
-    mkdir ${prefix}.plots
+    mkdir ${group_name}.plots
     mutation_densities_qc.py \\
                     --input-file ${all_mutdensities} \\
-                    --output-dir ${prefix}.plots \\
+                    --output-dir ${group_name}.plots \\
                     --panel ${panel_file} \\
-                    --samples ${samples_json}
+                    --group-definition ${groups_json} \\
+                    --group-name ${group_name}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/plot/qc/mutation_densities/main.nf
+++ b/modules/local/plot/qc/mutation_densities/main.nf
@@ -1,21 +1,20 @@
 process PLOT_MUTDENSITY_QC {
 
-    tag "all"
+    tag "${group_name}"
     label 'process_low'
 
     container "docker.io/bbglab/deepcsa-core:0.0.2-alpha"
 
     input:
-    path(all_mutdensities)
+    path (all_mutdensities)
     tuple val(meta2), path(panel_file)
     path (groups_json)
     val (group_name)
 
     output:
-    path("**.pdf")  , emit: plots
-    path("**.csv")  , emit: tables
-
-    path "versions.yml"              , topic: versions
+    path("**.pdf")      , emit: plots
+    path("**.csv")      , emit: tables
+    path "versions.yml" , topic: versions
 
 
     script:

--- a/subworkflows/local/plotting_qc/main.nf
+++ b/subworkflows/local/plotting_qc/main.nf
@@ -11,7 +11,8 @@ workflow PLOTTING_QC {
     // all_samples_depth
     // all_groups
     panel
-    samples
+    groups_definition
+    group_name
     // full_panel_rich
     // seqinfo_df
     // domain_df
@@ -30,7 +31,7 @@ workflow PLOTTING_QC {
     // .join( positive_selection_results_ready )
     // .set{ all_samples_results }
 
-    PLOTMUTDENSITYQC(all_mutdensities, panel, samples)
+    PLOTMUTDENSITYQC(all_mutdensities, panel, groups_definition, group_name)
     // mutation density per gene cohort-level
     // mutation density per gene & sample
     //      synonymous

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -571,7 +571,8 @@ workflow DEEPCSA{
                         // ANNOTATEDEPTHS.out.all_samples_depths,
                         // TABLE2GROUP.out.json_allgroups,
                         CREATEPANELS.out.exons_consensus_panel,
-                        TABLE2GROUP.out.json_samples,
+                        TABLE2GROUP.out.json_allgroups.first(),
+                        group_keys_ch
                         // CREATEPANELS.out.panel_annotated_rich,
                         // seqinfo_df,
                         // CREATEPANELS.out.domains_in_panel,

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -566,11 +566,11 @@ workflow DEEPCSA{
         // positive_selection_results_ready = positive_selection_results.map { element -> [element[0], element[1..-1]] }
         PLOTTINGQC(
                         // positive_selection_results_ready,
-                        all_mutdensities_file,
+                        all_mutdensities_file.first(),
                         // site_comparison_results,
                         // ANNOTATEDEPTHS.out.all_samples_depths,
                         // TABLE2GROUP.out.json_allgroups,
-                        CREATEPANELS.out.exons_consensus_panel,
+                        CREATEPANELS.out.exons_consensus_panel.first(),
                         TABLE2GROUP.out.json_allgroups.first(),
                         group_keys_ch
                         // CREATEPANELS.out.panel_annotated_rich,


### PR DESCRIPTION
- Update QCs code to work for all the groups defined in the study, in this way we ensure the basic QCs are run for all groups and help define whether omega can be used instead of omegagloballoc.



### AI generated
This pull request updates the mutation density QC plotting workflow to support group-based analysis rather than sample-based analysis. The changes refactor inputs and parameters to process mutation density QC plots for specific groups, improving flexibility and enabling cohort-level reporting.

**Workflow input and parameter refactoring:**

* Changed the `PLOT_MUTDENSITY_QC` process to accept `groups_json` and `group_name` instead of `samples_json`, enabling group-based mutation density QC plotting. The output directory and tag now use `group_name` for clarity and organization.
* Updated the `PLOTTING_QC` subworkflow to replace `samples` with `groups_definition` and `group_name` as inputs, aligning with the new group-based approach.

**Workflow invocation updates:**

* Modified the call to `PLOTMUTDENSITYQC` in the `PLOTTING_QC` subworkflow to use `groups_definition` and `group_name` instead of `samples`, ensuring correct parameter passing for group-based analysis.
* Updated the `DEEPCSA` workflow to pass the correct inputs to `PLOTTINGQC`, including using `.first()` to select the appropriate files and adding `group_keys_ch` for group names. This ensures compatibility with the new group-based QC plotting logic.