### PR TITLE
Add the option to generate complementary subgenic regions

### DIFF
--- a/bin/add_hotspots.py
+++ b/bin/add_hotspots.py
@@ -10,7 +10,8 @@ import numpy as np
 @click.option('--autoexons', type=click.Path(exists=True), default=None, help='BED file for automated exon definitions.')
 @click.option('--autodomains', type=click.Path(exists=True), default=None, help='BED file for automated domain definitions.')
 @click.option('--custom', type=click.Path(exists=True), default=None, help='BED file for custom region definitions.')
-def main(panel_file, autoexons, autodomains, custom):
+@click.option('--negative-regions', is_flag=True, default=False, help='Flag to generate negative regions for each newly defined subgenic region.')
+def main(panel_file, autoexons, autodomains, custom, negative_regions):
 
     # Read input data
     panel_data = pd.read_table(panel_file)
@@ -122,6 +123,26 @@ def main(panel_file, autoexons, autodomains, custom):
             new_data = pd.concat((new_data, hotspot_data))
             hotspots_names.append(region_name)
             print("Small region added:", region_name)
+
+            # If requested, also create the negative-region: all positions of the
+            # same gene that are NOT part of this specific hotspot region.
+            if negative_regions:
+                # all positions for this gene within the chromosome block
+                gene_all = chr_data[chr_data["GENE"] == gene]
+                # positions within the hotspot that belong to the gene
+                region_positions = chr_data.iloc[upd_start: upd_end + 1]
+                region_gene_positions = region_positions[region_positions["GENE"] == gene]
+
+                # negative rows = gene_all minus those in region_gene_positions
+                neg_rows = gene_all.loc[~gene_all.index.isin(region_gene_positions.index)].copy()
+                if not neg_rows.empty:
+                    neg_name = f"{region_name}--negative"
+                    neg_rows["GENE"] = neg_name
+                    new_data = pd.concat((new_data, neg_rows))
+                    hotspots_names.append(neg_name)
+                    print("Negative region added:", neg_name)
+                else:
+                    print(f"No negative-region positions for gene {gene} excluding {region_name}")
 
             # Increment region counter for the gene (if name is generated)
             if row.get("NAME") is None:

--- a/bin/add_hotspots.py
+++ b/bin/add_hotspots.py
@@ -10,8 +10,8 @@ import numpy as np
 @click.option('--autoexons', type=click.Path(exists=True), default=None, help='BED file for automated exon definitions.')
 @click.option('--autodomains', type=click.Path(exists=True), default=None, help='BED file for automated domain definitions.')
 @click.option('--custom', type=click.Path(exists=True), default=None, help='BED file for custom region definitions.')
-@click.option('--negative-regions', is_flag=True, default=False, help='Flag to generate negative regions for each newly defined subgenic region.')
-def main(panel_file, autoexons, autodomains, custom, negative_regions):
+@click.option('--subgenic-regions-complement', is_flag=True, default=False, help='Flag to generate negative regions for each newly defined subgenic region.')
+def main(panel_file, autoexons, autodomains, custom, subgenic_regions_complement):
 
     # Read input data
     panel_data = pd.read_table(panel_file)
@@ -124,25 +124,24 @@ def main(panel_file, autoexons, autodomains, custom, negative_regions):
             hotspots_names.append(region_name)
             print("Small region added:", region_name)
 
-            # If requested, also create the negative-region: all positions of the
+            # If requested, also create the complementary-region: all positions of the
             # same gene that are NOT part of this specific hotspot region.
-            if negative_regions:
+            if subgenic_regions_complement:
                 # all positions for this gene within the chromosome block
                 gene_all = chr_data[chr_data["GENE"] == gene]
                 # positions within the hotspot that belong to the gene
                 region_positions = chr_data.iloc[upd_start: upd_end + 1]
                 region_gene_positions = region_positions[region_positions["GENE"] == gene]
 
-                # negative rows = gene_all minus those in region_gene_positions
-                neg_rows = gene_all.loc[~gene_all.index.isin(region_gene_positions.index)].copy()
-                if not neg_rows.empty:
-                    neg_name = f"{region_name}--negative"
-                    neg_rows["GENE"] = neg_name
-                    new_data = pd.concat((new_data, neg_rows))
-                    hotspots_names.append(neg_name)
-                    print("Negative region added:", neg_name)
+                complement_rows = gene_all.loc[~gene_all.index.isin(region_gene_positions.index)].copy()
+                if not complement_rows.empty:
+                    complement_name = f"{region_name}--complement"
+                    complement_rows["GENE"] = complement_name
+                    new_data = pd.concat((new_data, complement_rows))
+                    hotspots_names.append(complement_name)
+                    print("Complement region added:", complement_name)
                 else:
-                    print(f"No negative-region positions for gene {gene} excluding {region_name}")
+                    print(f"No complement-region positions for gene {gene} excluding {region_name}")
 
             # Increment region counter for the gene (if name is generated)
             if row.get("NAME") is None:

--- a/modules/local/expand_regions/main.nf
+++ b/modules/local/expand_regions/main.nf
@@ -22,11 +22,13 @@ process EXPAND_REGIONS {
     def autoexons = params.omega_autoexons ? "--autoexons ${exons}" : ""
     def autodomains = params.omega_autodomains ? "--autodomains ${domains}" : ""
     def custom_regions = params.omega_subgenic_bedfile ? "--custom ${custom}" : ""
+    def negative_regions = params.omega_negative_regions ? "--negative-regions" : ""
     """
     add_hotspots.py --panel_file ${panel} \\
                         ${autoexons} \\
                         ${autodomains} \\
-                        ${custom_regions}
+                        ${custom_regions} \\
+                        ${negative_regions}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/expand_regions/main.nf
+++ b/modules/local/expand_regions/main.nf
@@ -22,13 +22,13 @@ process EXPAND_REGIONS {
     def autoexons = params.omega_autoexons ? "--autoexons ${exons}" : ""
     def autodomains = params.omega_autodomains ? "--autodomains ${domains}" : ""
     def custom_regions = params.omega_subgenic_bedfile ? "--custom ${custom}" : ""
-    def negative_regions = params.omega_negative_regions ? "--negative-regions" : ""
+    def subgenic_regions_complement = params.omega_subgenic_regions_complement ? "--subgenic-regions-complement" : ""
     """
     add_hotspots.py --panel_file ${panel} \\
                         ${autoexons} \\
                         ${autodomains} \\
                         ${custom_regions} \\
-                        ${negative_regions}
+                        ${subgenic_regions_complement}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,7 +58,7 @@ params {
     omega_withingene                         = false
     omega_autodomains                        = false
     omega_autoexons                          = false
-    omega_negative_regions                   = false
+    omega_subgenic_regions_complement        = false
     domains_file                             = null
     omega_subgenic_bedfile                   = null
     hotspot_expansion                        = 0

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,6 +58,7 @@ params {
     omega_withingene                         = false
     omega_autodomains                        = false
     omega_autoexons                          = false
+    omega_negative_regions                   = false
     domains_file                             = null
     omega_subgenic_bedfile                   = null
     hotspot_expansion                        = 0

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -268,11 +268,11 @@
                     "fa_icon": "fas fa-book",
                     "help_text": "Do you want to automatically generate the theoretical exons from the panel for omega?"
                 },
-                "omega_negative_regions": {
+                "omega_subgenic_regions_complement": {
                     "type": "boolean",
-                    "description": "Do you want to generate negative regions for subgenic regions in omega?",
+                    "description": "Do you want to generate complements for the subgenic regions?",
                     "fa_icon": "fas fa-book",
-                    "help_text": "Do you want to generate negative regions for subgenic regions in omega?"
+                    "help_text": "Do you want to generate complements for the subgenic regions?"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -267,6 +267,12 @@
                     "description": "Do you want to automatically generate the theoretical exons from the panel for omega?",
                     "fa_icon": "fas fa-book",
                     "help_text": "Do you want to automatically generate the theoretical exons from the panel for omega?"
+                },
+                "omega_negative_regions": {
+                    "type": "boolean",
+                    "description": "Do you want to generate negative regions for subgenic regions in omega?",
+                    "fa_icon": "fas fa-book",
+                    "help_text": "Do you want to generate negative regions for subgenic regions in omega?"
                 }
             }
         },


### PR DESCRIPTION
Update the add_hotspots.py script so that for each new subgenic region it also generates a new subgenic regions with the complementary part of the gene for the region, meaning a new region that contains all the positions of the gene except that specific domain/exon/subgenic region

- tested with domains, but not with exons

## AI summary
This pull request adds support for generating complements of subgenic regions in the pipeline. The main changes introduce a new parameter, update configuration files, and modify the process to handle this new option.

**Support for subgenic regions complement:**

* Added a new boolean parameter `omega_subgenic_regions_complement` to `nextflow.config` to control whether complements for subgenic regions should be generated.
* Updated `nextflow_schema.json` to include documentation and UI metadata for the new `omega_subgenic_regions_complement` parameter.

**Pipeline process updates:**

* Modified the `EXPAND_REGIONS` process in `modules/local/expand_regions/main.nf` to pass the `--subgenic-regions-complement` flag to `add_hotspots.py` when the new parameter is enabled.