### PR TITLE
Fix no filters usecase

### DIFF
--- a/bin/utils_filter.py
+++ b/bin/utils_filter.py
@@ -150,7 +150,7 @@ def extract_flagged_regions_bed(maf_df: pd.DataFrame, name: str, FILTERS: list[s
     if maf_df_filters.empty:
         LOG.warning("No mutations were flagged based on the applied filters. Creating empty BED file.")
         # Create empty BED file to satisfy pipeline requirements
-        Path(f"{name}.flagged-pos.bed").touch()
+        Path(f"{name}.{specification}flagged-pos.bed").touch()
         return
 
     # Create BED-like dataframe with filter columns

--- a/bin/write_mafs.py
+++ b/bin/write_mafs.py
@@ -96,8 +96,8 @@ def create_sample_flagged_bed(maf_df: pd.DataFrame, samples: list[str], filter_c
 @click.command()
 @click.option('--maf-file', required=True, type=click.Path(exists=True), help='Input gzipped MAF file (TSV)')
 @click.option('--groups-json', required=True, type=click.Path(exists=True), help='Optional JSON file with group/sample mapping')
-@click.option('--filters', required=True, type=str, default='', help='Comma-separated list of filter criteria')
-@click.option('--somatic-filters', required=True, type=str, default='', help='Comma-separated list of somatic filter criteria')
+@click.option('--filters', required=False, type=str, default='', help='Comma-separated list of filter criteria')
+@click.option('--somatic-filters', required=False, type=str, default='', help='Comma-separated list of somatic filter criteria')
 def main(maf_file, groups_json, filters: str, somatic_filters: str):
     maf_df = pd.read_csv(maf_file, compression='gzip', header=0, sep='\t', na_values=custom_na_values)
     maf_df["SAMPLE_ID"] = maf_df["SAMPLE_ID"].astype(str)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -228,8 +228,8 @@ process {
 
 
     withName: WRITEMAF {
-        ext.filters         = { params.filter_criteria.join(',') }
-        ext.somatic_filters = { params.filter_criteria_somatic.join(',') }
+        ext.filters         = params.filter_criteria ? params.filter_criteria.join(',') : ''
+        ext.somatic_filters = params.filter_criteria_somatic ? params.filter_criteria_somatic.join(',') : ''
 
         publishDir = [
             [

--- a/modules/local/writemaf/main.nf
+++ b/modules/local/writemaf/main.nf
@@ -10,11 +10,11 @@ process WRITE_MAFS {
     path (json_groups)
 
     output:
-    path("*.filtered.tsv.gz")                                       , emit: mafs
-    path("*.flagged-pos.bed")                                       , emit: sample_flagged_beds
-    path("all_samples.all-flagged-pos.bed")         , optional: true
-    path("all_samples.cohort-wide-flagged-pos.bed") , optional: true
-    path "versions.yml"                         , topic: versions
+    path("*.filtered.tsv.gz")                       , emit: mafs
+    path("*.flagged-pos.bed")                       , emit: sample_flagged_beds
+    path("all_samples.all-flagged-pos.bed")         
+    path("all_samples.cohort-wide-flagged-pos.bed") 
+    path "versions.yml"                             , topic: versions
 
     script:
     def filters = task.ext.filters ? "--filters \"${task.ext.filters}\"" : ""

--- a/modules/local/writemaf/main.nf
+++ b/modules/local/writemaf/main.nf
@@ -10,10 +10,10 @@ process WRITE_MAFS {
     path (json_groups)
 
     output:
-    path("*.filtered.tsv.gz")                   , emit: mafs
-    path("*.flagged-pos.bed")                   , emit: sample_flagged_beds
-    path("all_samples.all-flagged-pos.bed")
-    path("all_samples.cohort-wide-flagged-pos.bed")
+    path("*.filtered.tsv.gz")                                       , emit: mafs
+    path("*.flagged-pos.bed")                                       , emit: sample_flagged_beds
+    path("all_samples.all-flagged-pos.bed")         , optional: true
+    path("all_samples.cohort-wide-flagged-pos.bed") , optional: true
     path "versions.yml"                         , topic: versions
 
     script:

--- a/modules/local/writemaf/main.nf
+++ b/modules/local/writemaf/main.nf
@@ -17,14 +17,14 @@ process WRITE_MAFS {
     path "versions.yml"                         , topic: versions
 
     script:
-    def filters = task.ext.filters ?: ""
-    def somatic_filters = task.ext.somatic_filters ?: ""
+    def filters = task.ext.filters ? "--filters \"${task.ext.filters}\"" : ""
+    def somatic_filters = task.ext.somatic_filters ? "--somatic-filters \"${task.ext.somatic_filters}\"" : ""
     """
     write_mafs.py \\
         --maf-file ${maf} \\
         --groups-json ${json_groups} \\
-        --filters "${filters}" \\
-        --somatic-filters "${somatic_filters}"
+        ${filters} \\
+        ${somatic_filters}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
This PR implements some changes to fix a bug created by the updates regarding the reporting of positions to be masked and so on.

## AI summary
This pull request improves the handling of optional filter parameters and output files in the `WRITE_MAFS` process. The changes ensure that filters are only applied when specified and that certain output files are treated as optional, making the workflow more robust to missing or empty inputs.

Parameter handling improvements:

* Updated the assignment of `ext.filters` and `ext.somatic_filters` in `conf/modules.config` to set them to an empty string if the corresponding parameter is not provided, preventing errors from attempting to join a null value.
* Modified the construction of the `filters` and `somatic_filters` command-line arguments in `modules/local/writemaf/main.nf` to only include these options if the corresponding values are set, avoiding unnecessary or empty arguments in the script call.

Output file handling improvements:

* Marked the output files `all_samples.all-flagged-pos.bed` and `all_samples.cohort-wide-flagged-pos.bed` as optional in the `WRITE_MAFS` process, so the workflow will not fail if these files are not generated.