### PR TITLE
add decomposition of HDP with SigProfilerAssignment and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ We are working to provide the biggest possible detail on the [usage](docs/usage.
 
 > **Sex and smoking bias in the selection of somatic mutations in human bladder**
 >
-> Ferriol Calvet, Raquel Blanco Martinez-Illescas, Ferran Muiños, Maria Tretiakova, Elena S. Latorre-Esteves, Jeanne Fredrickson, Maria Andrianova, Stefano Pellegrini, Axel Rosendahl Huber, Joan Enric Ramis-Zaldivar, Shuyi Charlotte An, Elana Thieme, Brendan F. Kohrn, Miguel L. Grau, Abel Gonzalez-Perez, Nuria Lopez-Bigas & Rosa Ana Risques
+> Ferriol Calvet*, Raquel Blanco Martinez-Illescas*, Ferran Muiños, Maria Tretiakova, Elena S. Latorre-Esteves, Jeanne Fredrickson, Maria Andrianova, Stefano Pellegrini, Axel Rosendahl Huber, Joan Enric Ramis-Zaldivar, Shuyi Charlotte An, Elana Thieme, Brendan F. Kohrn, Miguel L. Grau, Abel Gonzalez-Perez, Nuria Lopez-Bigas & Rosa Ana Risques
 >
 >_Nature_ (2025) doi:[10.1038/s41586-025-09521-x](https://doi.org/10.1038/s41586-025-09521-x)
+>
+> *these authors contributed equally and the order was decided randomly
 
 > **DeepClone, an end-to-end protocol to study somatic mutagenesis and selection at high resolution**
 >
-> Ferriol Calvet, Morena Pinheiro-Santin, Erika Lopez,Raquel Blanco Martinez-Illescas, Núria Samper, Miguel L. Grau, Ferran Muiños,Rocío Chamorro González, Maria Andrianova, Federica Brando,Stefano Pellegrini, Marta Huertas, Elisabet Figuerola-Bou,Coohleen Coombes,Brendan F. Kohrn, Jeanne Fredrickson, Rosa Ana Risques, Nuria Lopez-Bigas, Abel Gonzalez-Perez
+> Ferriol Calvet, Morena Pinheiro-Santin, Erika Lopez, Raquel Blanco Martinez-Illescas, Núria Samper, Miguel L. Grau, Ferran Muiños, Rocío Chamorro González, Maria Andrianova, Federica Brando, Stefano Pellegrini, Marta Huertas, Elisabet Figuerola-Bou, Coohleen Coombes, Brendan F. Kohrn, Jeanne Fredrickson, Rosa Ana Risques, Nuria Lopez-Bigas, Abel Gonzalez-Perez
 >
 > _protocols.io_ (2026) doi:[10.17504/protocols.io.dm6gp1jodgzp/v2](https://dx.doi.org/10.17504/protocols.io.dm6gp1jodgzp/v2)

--- a/bin/concat_sigprot_matrices.py
+++ b/bin/concat_sigprot_matrices.py
@@ -41,6 +41,13 @@ def concat_sigprot_matrices(filename_of_matrices, samples_json_file, type_of_pro
 
     # Save the groups matrix if it exists
     if groups_matrix is not None and groups_matrix.shape[0] > 0:
+
+        # identify samples without mutations
+        zero_rows = groups_matrix.index[groups_matrix.sum(axis=1) == 0]
+        if len(zero_rows) > 0:
+            print(f"Excluding samples without mutations: {list(zero_rows)}")
+            groups_matrix = groups_matrix.drop(zero_rows)
+
         groups_matrix.reset_index().to_csv(f"groups_matrix.{type_of_profile}.sp.tsv", sep='\t', header=True, index=False)
         groups_matrix.round().astype(int).reset_index().to_csv(f"groups_matrix.{type_of_profile}.sp.round.tsv", sep='\t', header=True, index=False)
 
@@ -55,6 +62,13 @@ def concat_sigprot_matrices(filename_of_matrices, samples_json_file, type_of_pro
 
     # Save the samples matrix if it exists
     if samples_only_matrix is not None and samples_only_matrix.shape[0] > 0:
+
+        # identify samples without mutations
+        zero_rows = samples_only_matrix.index[samples_only_matrix.sum(axis=1) == 0]
+        if len(zero_rows) > 0:
+            print(f"Excluding samples without mutations: {list(zero_rows)}")
+            samples_only_matrix = samples_only_matrix.drop(zero_rows)
+
         samples_only_matrix.reset_index().to_csv(f"samples_matrix.{type_of_profile}.sp.tsv", sep='\t', header=True, index=False)
         samples_only_matrix.round().astype(int).reset_index().to_csv(f"samples_matrix.{type_of_profile}.sp.round.tsv", sep='\t', header=True, index=False)
 

--- a/bin/concat_sigprot_matrices.py
+++ b/bin/concat_sigprot_matrices.py
@@ -5,6 +5,14 @@ import pandas as pd
 import json
 
 
+# identify samples without mutations
+def remove_zero_mutation_samples(matrix):
+    zero_col = matrix.columns[matrix.sum(axis=0) == 0]
+    if len(zero_col) > 0:
+        print(f"Excluding samples without mutations: {list(zero_col)}")
+        matrix = matrix.drop(columns=zero_col)
+    return matrix
+
 def concat_sigprot_matrices(filename_of_matrices, samples_json_file, type_of_profile):
     """
     Concatenate signature profile matrices for samples and groups.
@@ -41,15 +49,11 @@ def concat_sigprot_matrices(filename_of_matrices, samples_json_file, type_of_pro
 
     # Save the groups matrix if it exists
     if groups_matrix is not None and groups_matrix.shape[0] > 0:
-
-        # identify samples without mutations
-        zero_rows = groups_matrix.index[groups_matrix.sum(axis=1) == 0]
-        if len(zero_rows) > 0:
-            print(f"Excluding samples without mutations: {list(zero_rows)}")
-            groups_matrix = groups_matrix.drop(zero_rows)
+        groups_matrix = remove_zero_mutation_samples(groups_matrix)
 
         groups_matrix.reset_index().to_csv(f"groups_matrix.{type_of_profile}.sp.tsv", sep='\t', header=True, index=False)
-        groups_matrix.round().astype(int).reset_index().to_csv(f"groups_matrix.{type_of_profile}.sp.round.tsv", sep='\t', header=True, index=False)
+        rounded_groups_matrix = remove_zero_mutation_samples(groups_matrix.round().astype(int))
+        rounded_groups_matrix.reset_index().to_csv(f"groups_matrix.{type_of_profile}.sp.round.tsv", sep='\t', header=True, index=False)
 
         # HDP
         groups_matrix = groups_matrix.transpose()
@@ -62,15 +66,11 @@ def concat_sigprot_matrices(filename_of_matrices, samples_json_file, type_of_pro
 
     # Save the samples matrix if it exists
     if samples_only_matrix is not None and samples_only_matrix.shape[0] > 0:
-
-        # identify samples without mutations
-        zero_rows = samples_only_matrix.index[samples_only_matrix.sum(axis=1) == 0]
-        if len(zero_rows) > 0:
-            print(f"Excluding samples without mutations: {list(zero_rows)}")
-            samples_only_matrix = samples_only_matrix.drop(zero_rows)
+        samples_only_matrix = remove_zero_mutation_samples(samples_only_matrix)
 
         samples_only_matrix.reset_index().to_csv(f"samples_matrix.{type_of_profile}.sp.tsv", sep='\t', header=True, index=False)
-        samples_only_matrix.round().astype(int).reset_index().to_csv(f"samples_matrix.{type_of_profile}.sp.round.tsv", sep='\t', header=True, index=False)
+        rounded_samples_only_matrix = remove_zero_mutation_samples(samples_only_matrix.round().astype(int))
+        rounded_samples_only_matrix.reset_index().to_csv(f"samples_matrix.{type_of_profile}.sp.round.tsv", sep='\t', header=True, index=False)
 
         # HDP
         samples_only_matrix = samples_only_matrix.transpose()

--- a/bin/mut_profile.py
+++ b/bin/mut_profile.py
@@ -204,7 +204,7 @@ def compute_mutation_profile(sample_name, mutation_matrix_file, trinucleotide_co
     # compute profile stability and store the outputs in a file
     stability_output_dict = profile_stability(mutation_matrix[sample_name], contextmut_depth[sample_name])
     stability_outputs = pd.DataFrame(stability_output_dict.items()).set_index(0).T
-    stability_outputs[["SAMPLE_ID", "mode"]] = sample_name.split(("."))
+    stability_outputs[["SAMPLE_ID", "mode"]] = sample_name.split(".")
     stability_outputs[["SAMPLE_ID", "mode"] + list(stability_outputs.columns[:-2])].to_csv(f"{sample_name}.profile_stability.tsv", sep = "\t", index = False)
 
 

--- a/bin/mut_profile.py
+++ b/bin/mut_profile.py
@@ -98,6 +98,72 @@ def compute_mutation_matrix(sample_name, mutations_file, mutation_matrix, method
                                             sep = "\t")
 
 
+
+def profile_stability(counts, denominator):
+    """
+    Compute stability score of a probability profile by
+    adding +1 to each channel individually and measuring
+    L1 (Total Variation) deviation.
+
+    Parameters
+    ----------
+    counts : array-like, shape (k,)
+        Raw integer counts per channel.
+    denominator : array-like, shape (k,)
+        Denominator for each channel (e.g., trinucleotide counts).
+
+    Returns
+    -------
+    results : dict
+        {
+            'mean_deviation': float,
+            'max_deviation': float,
+            'std_deviation': float,
+            'all_deviations': np.ndarray shape (k,)
+        }
+    """
+
+    # Convert to numpy arrays
+    counts = np.asarray(counts, dtype=float)
+    denominator = np.asarray(denominator, dtype=float)
+
+    if counts.ndim != 1:
+        raise ValueError("counts must be a 1D vector")
+    if denominator.ndim != 1:
+        raise ValueError("denominator must be a 1D vector")
+    if len(counts) != len(denominator):
+        raise ValueError("counts and denominator must have same length")
+    if np.any(denominator == 0):
+        raise ValueError("denominator contains zeros")
+
+    k = len(counts)
+
+    # ---- Baseline profile ----
+    ref_profile = counts / denominator
+    ref_profile = ref_profile / ref_profile.sum()
+    p = ref_profile
+
+    deviations = np.zeros(k)
+
+    # ---- Perturb each channel ----
+    for j in range(k):
+        perturbed = counts.copy()
+        perturbed[j] += 1
+
+        p_prime = perturbed / denominator
+        p_prime = p_prime / p_prime.sum()  # IMPORTANT: renormalize
+
+        deviations[j] = 0.5 * np.sum(np.abs(p - p_prime))
+
+    return {
+        "mean_deviation": deviations.mean(),
+        "min_deviation": deviations.min(),
+        "max_deviation": deviations.max(),
+        "std_deviation": deviations.std(),
+        "all_deviations": deviations
+    }
+
+
 def compute_mutation_profile(sample_name, mutation_matrix_file, trinucleotide_counts_file, plot,
                                 wgs = False, wgs_trinucleotide_counts = False, sigprofiler = False):
     """
@@ -116,8 +182,9 @@ def compute_mutation_profile(sample_name, mutation_matrix_file, trinucleotide_co
     total_mutations = np.sum(mutation_matrix[sample_name])
 
     # proportion of SBS mutations per trinucleotide in panel
-    mutation_matrix[sample_name] = mutation_matrix[sample_name] / total_mutations
-    mutation_matrix.to_csv(f"{sample_name}.proportion_mutations.tsv",
+    mutation_matrix_proportions = mutation_matrix.copy()
+    mutation_matrix_proportions[sample_name] = mutation_matrix_proportions[sample_name] / total_mutations
+    mutation_matrix_proportions.to_csv(f"{sample_name}.proportion_mutations.tsv",
                                 header = True,
                                 index = True,
                                 sep = "\t")
@@ -133,6 +200,13 @@ def compute_mutation_profile(sample_name, mutation_matrix_file, trinucleotide_co
 
     contextmut_depth = pd.DataFrame({sample_name : trinuc_per_contextmuts, "CONTEXT_MUT": contexts_formatted})
     contextmut_depth = contextmut_depth.set_index("CONTEXT_MUT")
+
+    # compute profile stability and store the outputs in a file
+    stability_output_dict = profile_stability(mutation_matrix[sample_name], contextmut_depth[sample_name])
+    stability_outputs = pd.DataFrame(stability_output_dict.items()).set_index(0).T
+    stability_outputs[["SAMPLE_ID", "mode"]] = sample_name.split(("."))
+    stability_outputs[["SAMPLE_ID", "mode"] + list(stability_outputs.columns[2:])].to_csv(f"{sample_name}.profile_stability.tsv", sep = "\t", index = False)
+
 
     # divide
     mut_probability = mutation_matrix.divide( contextmut_depth )
@@ -171,7 +245,7 @@ def compute_mutation_profile(sample_name, mutation_matrix_file, trinucleotide_co
                         output_f = f'{sample_name}.profile.pdf')
 
         # plot the profile as a percentage of SBS mutations seen in our sequenced panel
-        plot_profile(dict(zip(mutation_matrix.index, mutation_matrix[sample_name])),
+        plot_profile(dict(zip(mutation_matrix_proportions.index, mutation_matrix_proportions[sample_name])),
                         title=f'{sample_name} ({round(total_mutations)} muts)',
                         output_f = f'{sample_name}.profile.percentage.pdf')
 

--- a/bin/mut_profile.py
+++ b/bin/mut_profile.py
@@ -160,7 +160,7 @@ def profile_stability(counts, denominator):
         "min_deviation": deviations.min(),
         "max_deviation": deviations.max(),
         "std_deviation": deviations.std(),
-        "all_deviations": deviations
+        "all_deviations": deviations.tolist()
     }
 
 
@@ -205,7 +205,7 @@ def compute_mutation_profile(sample_name, mutation_matrix_file, trinucleotide_co
     stability_output_dict = profile_stability(mutation_matrix[sample_name], contextmut_depth[sample_name])
     stability_outputs = pd.DataFrame(stability_output_dict.items()).set_index(0).T
     stability_outputs[["SAMPLE_ID", "mode"]] = sample_name.split(("."))
-    stability_outputs[["SAMPLE_ID", "mode"] + list(stability_outputs.columns[2:])].to_csv(f"{sample_name}.profile_stability.tsv", sep = "\t", index = False)
+    stability_outputs[["SAMPLE_ID", "mode"] + list(stability_outputs.columns[:-2])].to_csv(f"{sample_name}.profile_stability.tsv", sep = "\t", index = False)
 
 
     # divide

--- a/bin/panel_postprocessing_annotation.py
+++ b/bin/panel_postprocessing_annotation.py
@@ -4,15 +4,13 @@ import click
 import pandas as pd
 import numpy as np
 from itertools import product
-from bgreference import hg38, hg19, mm10, mm39
+from bgreference import hg38, mm39
 from utils_context import transform_context
 from utils_impacts import *
 from read_utils import custom_na_values
 
 assembly_name2function = {
     "hg38": hg38,
-    "hg19": hg19,
-    "mm10": mm10,
     "mm39": mm39
 }
 
@@ -199,7 +197,7 @@ def vep2summarizedannotation_panel(VEP_output_file, all_possible_sites_annotated
 
 @click.command()
 @click.option('--vep_output_file', type=click.Path(exists=True), required=True, help='Path to the VEP output file.')
-@click.option('--assembly', type=click.Choice(['hg38', 'hg19', 'mm10', 'mm39']), default='hg38', help='Genome assembly.')
+@click.option('--assembly', type=click.Choice(['hg38', 'mm39']), default='hg38', help='Genome assembly.')
 @click.option('--output_file', type=click.Path(), required=True, help='Path to the output annotated file.')
 @click.option('--only_canonical', is_flag=True, default=False, help='Use only canonical transcripts.')
 def main(vep_output_file, assembly, output_file, only_canonical):

--- a/bin/postprocessing_annotation.py
+++ b/bin/postprocessing_annotation.py
@@ -4,7 +4,7 @@ import sys
 import click
 import pandas as pd
 
-from bgreference import hg38, hg19, mm10, mm39
+from bgreference import hg38, mm39
 
 from utils import vartype
 from utils_context import transform_context
@@ -12,8 +12,6 @@ from utils_impacts import *
 from read_utils import custom_na_values
 
 assembly_name2function = {"hg38": hg38,
-                            "hg19": hg19,
-                            "mm10": mm10,
                             "mm39": mm39}
 
 
@@ -245,7 +243,7 @@ def vep2summarizedannotation(VEP_output_file, all_possible_sites_annotated_file,
 @click.command()
 @click.argument('vep_output_file', type=click.Path(exists=True))
 @click.argument('all_possible_sites_annotated_file', type=click.Path())
-@click.option('--assembly-name', default='hg38', show_default=True, type=click.Choice(['hg38', 'hg19', 'mm10', 'mm39']), help='Reference genome assembly name')
+@click.option('--assembly-name', default='hg38', show_default=True, type=click.Choice(['hg38', 'mm39']), help='Reference genome assembly name')
 @click.option('--all-underscore', is_flag=True, default=False, show_default=True, help='Whether to use _ to separate all parts of MUT_ID (default: False)')
 @click.option('--hotspots-annotation-file', default=None, type=click.Path(exists=False), help='Path to hotspots annotation file')
 @click.option('--gnomad-af-threshold', default=0.001, show_default=True, type=float, help='gnomAD allele frequency threshold')

--- a/bin/sites_table_from_positions.py
+++ b/bin/sites_table_from_positions.py
@@ -4,11 +4,9 @@
 import click
 import pandas as pd
 
-from bgreference import hg38, hg19, mm10, mm39
+from bgreference import hg38, mm39
 
 assembly_name2function = {"hg38": hg38,
-                            "hg19": hg19,
-                            "mm10": mm10,
                             "mm39": mm39
                             }
 
@@ -49,7 +47,6 @@ def generate_all_sites_4VEP(input_positions, genome, output_file_with_sites):
 
 @click.command()
 @click.option('--input-positions', required=True, type=click.Path(exists=True), help='Input positions file (TSV)')
-#@click.option('--genome-assembly', required=True, type=click.Choice(['hg38', 'hg19', 'mm10', 'mm39']), help='Genome assembly (hg38, hg19, mm10, mm39)')
 @click.option('--genome-assembly', required=True, type=click.Choice(['hg38', 'mm39']), help='Genome assembly (hg38, mm39)')
 @click.option('--output-file-with-sites', required=True, type=click.Path(), help='Output file for sites (TSV)')
 def main(input_positions, genome_assembly, output_file_with_sites):

--- a/bin/utils_context.py
+++ b/bin/utils_context.py
@@ -1,4 +1,4 @@
-from bgreference import hg38, hg19, mm10, mm39
+from bgreference import hg38, mm39
 
 from itertools import product
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -542,6 +542,14 @@ process {
                             --seed 123"
     }
 
+    withName: 'SIGPROFILERASSIGNMENT|HDPREASSIGNMENT|SIGPROMATRIXGENERATOR' {
+        ext.genome_assembly = params.vep_genome == 'GRCh38'
+            ? 'GRCh38'
+            : params.vep_genome == 'GRCm39'
+                ? 'mm39'
+                : null
+    }
+
     withName: SIGPROFILERASSIGNMENT {
         publishDir = [
             [
@@ -577,11 +585,7 @@ process {
                             --tsb_stat \
                             --seqInfo \
                             --cushion 100"
-        ext.genome_assembly = params.vep_genome == 'GRCh38'
-            ? 'GRCh38'
-            : params.vep_genome == 'GRCm39'
-                ? 'mm39'
-                : null
+
         publishDir          = [
             [
                 mode: params.publish_dir_mode,
@@ -644,7 +648,7 @@ process {
                         --missing_values mean_samples"
     }
 
-    withName: 'SITESFROMPOSITIONS|SUMANNOTATION|SIGPROFILERASSIGNMENT|ONCODRIVECLUSTL|POSTPROCESSVEPPANEL' {
+    withName: 'SITESFROMPOSITIONS|SUMANNOTATION|ONCODRIVECLUSTL|POSTPROCESSVEPPANEL' {
         ext.assembly = params.vep_genome == 'GRCh38'
             ? 'hg38'
             : params.vep_genome == 'GRCm39'

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -553,13 +553,9 @@ process {
                             --cushion 100"
         ext.genome_assembly = params.vep_genome == 'GRCh38'
             ? 'GRCh38'
-            : params.vep_genome == 'GRCh37'
-                ? 'GRCh37'
-                : params.vep_genome == 'GRCm38'
-                    ? 'mm10'
-                    : params.vep_genome == 'GRCm39'
-                        ? 'mm39'
-                        : null
+            : params.vep_genome == 'GRCm39'
+                ? 'mm39'
+                : null
         publishDir          = [
             [
                 mode: params.publish_dir_mode,
@@ -625,11 +621,9 @@ process {
     withName: 'SITESFROMPOSITIONS|SUMANNOTATION|SIGPROFILERASSIGNMENT|ONCODRIVECLUSTL|POSTPROCESSVEPPANEL' {
         ext.assembly = params.vep_genome == 'GRCh38'
             ? 'hg38'
-            : params.vep_genome == 'GRCm38'
-                ? 'mm10'
-                : params.vep_genome == 'GRCm39'
-                    ? 'mm39'
-                    : null
+            : params.vep_genome == 'GRCm39'
+                ? 'mm39'
+                : null
     }
 
     withLabel : deepcsa_core {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -546,6 +546,26 @@ process {
         ]
     }
 
+    withName: HDPREASSIGNMENT {
+        publishDir = [
+            [
+                mode: params.publish_dir_mode,
+                path: { "${params.outdir}/signatures/hdp_decomposition_spa" },
+                pattern: "**{txt,pdf}",
+            ]
+        ]
+    }
+
+    withName: REFORMATSIGNATURES {
+        publishDir = [
+            [
+                mode: params.publish_dir_mode,
+                path: { "${params.outdir}/signatures/signatures_hdp/signatures_reformatted" },
+                pattern: "**{tsv}",
+            ]
+        ]
+    }
+
     withName: SIGPROMATRIXGENERATOR {
         ext.args            = "--plot \
                             --tsb_stat \

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -239,7 +239,7 @@ process {
             ],
             [
                 mode: params.publish_dir_mode,
-                path: { "${params.outdir}/flagged_positions" },
+                path: { "${params.outdir}/processing_files/flagged_positions" },
                 pattern: "*{bed}",
             ]
         ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -112,7 +112,7 @@ process {
     }
 
 
-    withName: QUERYMUTATIONS {
+    withName: 'QUERYMUTATIONS|QUERYMUTATIONSEXONS' {
         ext.prefix    = { ".subset_mutations" }
         ext.args      = ''
         ext.args2     = '-s 1 -b 2 -e 2'

--- a/conf/tools/omega.config
+++ b/conf/tools/omega.config
@@ -168,10 +168,8 @@ process {
     withName: 'PREPROCESSING.*|ESTIMATOR.*' {
         ext.assembly = params.vep_genome == 'GRCh38'
             ? 'hg38'
-            : params.vep_genome == 'GRCm38'
-                ? 'mm10'
-                : params.vep_genome == 'GRCm39'
-                    ? 'mm39'
-                    : null
+            : params.vep_genome == 'GRCm39'
+                ? 'mm39'
+                : null
     }
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -274,7 +274,7 @@ These files identify sites overlapping common SNPs and noisy or variable genomic
 - Nanoseq SNP: Common SNP positions that should be excluded from analysis
 - Nanoseq Noise: Regions with high noise or variability
 
-Both files are available for GRCh37 and GRCh38 at the [shared folder](https://drive.google.com/drive/folders/1wqkgpRTuf4EUhqCGSLA4fIg9qEEw3ZcL) from Iñigo Martincorena's group, at the Wellcome Sanger Institute.
+Both files are available for GRCh38 at the [shared folder](https://drive.google.com/drive/folders/1wqkgpRTuf4EUhqCGSLA4fIg9qEEw3ZcL) from Iñigo Martincorena's group, at the Wellcome Sanger Institute.
 
 ## Additional customizable parameters
 

--- a/modules/local/compute_profile/main.nf
+++ b/modules/local/compute_profile/main.nf
@@ -16,6 +16,7 @@ process COMPUTE_PROFILE {
     tuple val(meta), path("*.proportion_mutations.WGS.tsv") , optional:true , emit: wgs_proportions
     tuple val(meta), path("*.matrix.WGS.tsv")               , optional:true , emit: wgs
     tuple val(meta), path("*.matrix.WGS.sigprofiler.tsv")   , optional:true , emit: wgs_sigprofiler
+    tuple val(meta), path("*.profile_stability.tsv")                        , emit: profile_stability
 
     tuple val(meta), path("*.pdf")                          , optional:true , emit: plots
 

--- a/modules/local/dna2protein/main.nf
+++ b/modules/local/dna2protein/main.nf
@@ -1,6 +1,7 @@
 process DNA_2_PROTEIN_MAPPING {
     tag "$meta.id"
     label 'process_single'
+    label 'process_medium_high_memory'
 
     label 'deepcsa_core'
 

--- a/modules/local/dna2protein/main.nf
+++ b/modules/local/dna2protein/main.nf
@@ -21,18 +21,18 @@ process DNA_2_PROTEIN_MAPPING {
 
 
     script:
-    def ensembl_release = task.ext.ensembl_release
-    def ensembl_species = task.ext.ensembl_species
-    def ensembl_genome  = task.ext.ensembl_genome
+    def ensembl_release = "--ensembl-release \"${task.ext.ensembl_release}\""
+    def ensembl_species = "--ensembl-species \"${task.ext.ensembl_species}\""
+    def ensembl_genome  = "--ensembl-genome \"${task.ext.ensembl_genome}\""
     """
     cut -f 1,2,6 ${panel_file} | uniq > ${meta2.id}.panel.unique.tsv
     panels_computedna2protein.py \\
                 --mutations-file ${mutations_file} \\
                 --consensus-file ${meta2.id}.panel.unique.tsv \\
                 --depths-file ${all_samples_depths} \\
-                --ensembl-release ${ensembl_release} \\
-                --ensembl-species ${ensembl_species} \\
-                --ensembl-genome ${ensembl_genome}
+                ${ensembl_release} \\
+                ${ensembl_species} \\
+                ${ensembl_genome}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/signatures/hdp/process_results/main.nf
+++ b/modules/local/signatures/hdp/process_results/main.nf
@@ -38,6 +38,7 @@ process  PROCESS_HDP_RESULTS {
     prefix = "${meta.id}${prefix}"
     """
     touch ${prefix}.pdf
+    touch components.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/signatures/hdp/process_results/main.nf
+++ b/modules/local/signatures/hdp/process_results/main.nf
@@ -10,7 +10,7 @@ process  PROCESS_HDP_RESULTS {
 
     output:
     tuple val(meta), path("output_dir")         , emit: processed_results
-    tuple val(meta), path("**/components.txt")   , emit: signatures
+    tuple val(meta), path("**/components.txt")  , emit: signatures
     path "versions.yml"                         , topic: versions
 
 

--- a/modules/local/signatures/hdp/process_results/main.nf
+++ b/modules/local/signatures/hdp/process_results/main.nf
@@ -9,8 +9,9 @@ process  PROCESS_HDP_RESULTS {
     tuple val(meta2), path (iteration_dir)
 
     output:
-    tuple val(meta), path("output_dir"), emit: processed_results
-    path "versions.yml"                , topic: versions
+    tuple val(meta), path("output_dir")         , emit: processed_results
+    tuple val(meta), path("**/components.txt")   , emit: signatures
+    path "versions.yml"                         , topic: versions
 
 
     script:

--- a/modules/local/signatures/hdp/process_results/main.nf
+++ b/modules/local/signatures/hdp/process_results/main.nf
@@ -37,8 +37,9 @@ process  PROCESS_HDP_RESULTS {
     def prefix = task.ext.prefix ?: ""
     prefix = "${meta.id}${prefix}"
     """
-    touch ${prefix}.pdf
-    touch components.txt
+    mkdir -p output_dir  
+    touch ${prefix}.pdf  
+    touch output_dir/components.txt 
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/signatures/hdp/reformat_sigs/main.nf
+++ b/modules/local/signatures/hdp/reformat_sigs/main.nf
@@ -1,0 +1,46 @@
+
+process SIGNATURES_HDP_TO_SIGPROFILER {
+    tag "$meta.id"
+    label 'process_medium'
+    label 'deepcsa_core'
+
+
+    input:
+    tuple val(meta), path (signatures)
+
+    output:
+    tuple val(meta), path("*.tsv")  , emit: signatures_for_sp
+    path "versions.yml"             , topic: versions
+
+
+    script:
+    def prefix = task.ext.prefix ?: ""
+    prefix = "${meta.id}${prefix}"
+    """
+    #!/usr/bin/env python
+
+    import pandas as pd
+    data = pd.read_table("${signatures}")
+    data = data.sort_index().reset_index()
+    data.columns = ["Type"] + [f"HDP_{x}" for x in data.columns[1:] ]
+    data.to_csv("${signatures.baseName}.sp_formatted.tsv", sep = '\t', header = True, index = False)
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: ""
+    prefix = "${meta.id}${prefix}"
+    """
+    touch ${prefix}.pdf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+
+}

--- a/modules/local/signatures/hdp/reformat_sigs/main.nf
+++ b/modules/local/signatures/hdp/reformat_sigs/main.nf
@@ -17,14 +17,13 @@ process SIGNATURES_HDP_TO_SIGPROFILER {
     def prefix = task.ext.prefix ?: ""
     prefix = "${meta.id}${prefix}"
     """
-    #!/usr/bin/env python
-
-    import pandas as pd
-    data = pd.read_table("${signatures}")
-    data = data.sort_index().reset_index()
-    data.columns = ["Type"] + [f"HDP_{x}" for x in data.columns[1:] ]
-    data.to_csv("${signatures.baseName}.sp_formatted.tsv", sep = '\t', header = True, index = False)
-
+    python <<CODE
+import pandas as pd
+data = pd.read_table("${signatures}")
+data = data.sort_index().reset_index()
+data.columns = ["Type"] + [f"HDP_{x}" for x in data.columns[1:]]
+data.to_csv("${signatures.baseName}.sp_formatted.tsv", sep='\\t', header=True, index=False)
+CODE
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')

--- a/modules/local/signatures/hdp/reformat_sigs/main.nf
+++ b/modules/local/signatures/hdp/reformat_sigs/main.nf
@@ -24,11 +24,12 @@ data = data.sort_index().reset_index()
 data.columns = ["Type"] + [f"HDP_{x}" for x in data.columns[1:]]
 data.to_csv("${signatures.baseName}.sp_formatted.tsv", sep='\\t', header=True, index=False)
 CODE
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
-    END_VERSIONS
-    """
+
+cat <<-END_VERSIONS > versions.yml
+"${task.process}":
+    python: \$(python --version | sed 's/Python //g')
+END_VERSIONS
+    """    
 
     stub:
     def prefix = task.ext.prefix ?: ""

--- a/modules/local/signatures/hdp/reformat_sigs/main.nf
+++ b/modules/local/signatures/hdp/reformat_sigs/main.nf
@@ -35,7 +35,7 @@ END_VERSIONS
     def prefix = task.ext.prefix ?: ""
     prefix = "${meta.id}${prefix}"
     """
-    touch ${prefix}.pdf
+    touch ${prefix}.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/signatures/sigprofiler/assignment/cosmic_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/cosmic_fit/main.nf
@@ -39,8 +39,7 @@ process SIGPROFILERASSIGNMENT_COSMIC_FIT {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
-        SigProfilerAssignment : 0.1.1
+        SigProfilerAssignment : 1.1.3
     END_VERSIONS
     """
 
@@ -52,8 +51,7 @@ process SIGPROFILERASSIGNMENT_COSMIC_FIT {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
-        SigProfilerAssignment : 0.1.1
+        SigProfilerAssignment : 1.1.3
     END_VERSIONS
     """
 }

--- a/modules/local/signatures/sigprofiler/assignment/cosmic_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/cosmic_fit/main.nf
@@ -35,7 +35,7 @@ process SIGPROFILERASSIGNMENT_COSMIC_FIT {
             --cpu ${task.cpus} \\
             --volume spa_volume
 
-    mv output_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.txt output_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.${name}.txt;
+    cp output_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.txt output_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.${name}.txt;
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/signatures/sigprofiler/assignment/cosmic_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/cosmic_fit/main.nf
@@ -17,7 +17,7 @@ process SIGPROFILERASSIGNMENT_COSMIC_FIT {
 
     script:
     def name = "${meta.id}.${type}"
-    def assembly = task.ext.assembly ?: "GRCh38"
+    def assembly = task.ext.genome_assembly ?: "GRCh38"
     
     // FIXME: the definition of subgroups to exclude seems not to work in the new CLI SigProfilerAssignment
     // def exclude_signature_subgroups = params.exclude_subgroups ? "--exclude_signature_subgroups \"${params.exclude_subgroups}\"" : ""

--- a/modules/local/signatures/sigprofiler/assignment/cosmic_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/cosmic_fit/main.nf
@@ -1,0 +1,59 @@
+process SIGPROFILERASSIGNMENT_COSMIC_FIT {
+    tag "$meta.id"
+    label 'process_medium'
+
+    container 'docker.io/ferriolcalvet/sigprofiler_assignment:1.1.3'
+
+    input:
+    tuple val(meta), val(type), path(matrix)
+    path(reference_signatures)
+
+    output:
+    tuple val(meta), path("**.pdf")                                         , emit: plots
+    tuple val(meta), path("**.txt")                                         , emit: stats
+    tuple val(meta), path("**Decomposed_MutationType_Probabilities.*.txt")  , emit: mutation_probs
+    path "versions.yml"                                                     , topic: versions
+
+
+    script:
+    def name = "${meta.id}.${type}"
+    def assembly = task.ext.assembly ?: "GRCh38"
+    
+    // FIXME: the definition of subgroups to exclude seems not to work in the new CLI SigProfilerAssignment
+    // def exclude_signature_subgroups = params.exclude_subgroups ? "--exclude_signature_subgroups \"${params.exclude_subgroups}\"" : ""
+    """
+    mkdir -p spa_volume
+    export SIGPROFILERMATRIXGENERATOR_VOLUME='./spa_volume'
+    export SIGPROFILERPLOTTING_VOLUME='./spa_volume'
+    export SIGPROFILERASSIGNMENT_VOLUME='./spa_volume'
+
+    SigProfilerAssignment cosmic_fit \\
+            ${matrix} \\
+            output_${name} \\
+            --signature_database ${reference_signatures} \\
+            --genome_build ${assembly} \\
+            --cpu ${task.cpus} \\
+            --volume spa_volume
+
+    mv output_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.txt output_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.${name}.txt;
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+        SigProfilerAssignment : 0.1.1
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: ""
+    prefix = "${meta.id}${prefix}"
+    """
+    touch ${prefix}.pdf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version | sed 's/Python //g')
+        SigProfilerAssignment : 0.1.1
+    END_VERSIONS
+    """
+}

--- a/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
@@ -54,7 +54,7 @@ process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
     """
     touch ${prefix}.pdf
     touch ${prefix}.txt
-    touch ${prefix}.Decomposed_MutationType_Probabilities.txt
+    touch Decomposed_MutationType_Probabilities.${prefix}.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
@@ -53,6 +53,8 @@ process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
     prefix = "${meta.id}${prefix}"
     """
     touch ${prefix}.pdf
+    touch ${prefix}.txt
+    touch ${prefix}.Decomposed_MutationType_Probabilities.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
@@ -19,7 +19,7 @@ process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
     script:
     def args = task.ext.args ?: ''
     def name = "${meta.id}.${type}"
-    def assembly = task.ext.assembly ?: "GRCh38"
+    def assembly = task.ext.genome_assembly ?: "GRCh38"
     
     // FIXME: the definition of subgroups to exclude seems not to work in the new CLI SigProfilerAssignment
     // def exclude_signature_subgroups = params.exclude_subgroups ? "--exclude_signature_subgroups \"${params.exclude_subgroups}\"" : ""

--- a/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
@@ -43,7 +43,6 @@ process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
         SigProfilerAssignment : 1.1.3
     END_VERSIONS
     """
@@ -58,7 +57,6 @@ process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
         SigProfilerAssignment : 1.1.3
     END_VERSIONS
     """

--- a/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
@@ -6,7 +6,7 @@ process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
 
     input:
     tuple val(meta), val(type), path(matrix)
-    path (extracted_signatures)
+    tuple val(meta2), path (extracted_signatures)
     path (reference_signatures)
 
     output:
@@ -17,6 +17,7 @@ process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
 
 
     script:
+    def args = task.ext.args ?: ''
     def name = "${meta.id}.${type}"
     def assembly = task.ext.assembly ?: "GRCh38"
     
@@ -35,9 +36,10 @@ process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
             --signature_database ${reference_signatures} \\
             --genome_build ${assembly} \\
             --cpu ${task.cpus} \\
-            --volume spa_volume
+            --volume spa_volume \\
+            ${args}
 
-    #mv signature_decomposition_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.txt signature_decomposition_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.${name}.txt;
+    cp signature_decomposition_${name}/Decompose_Solution/Activities/Decomposed_MutationType_Probabilities.txt signature_decomposition_${name}/Decompose_Solution/Activities/Decomposed_MutationType_Probabilities.${name}.txt;
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
+++ b/modules/local/signatures/sigprofiler/assignment/decompose_fit/main.nf
@@ -1,4 +1,4 @@
-process SIGPROFILERASSIGNMENT {
+process SIGPROFILERASSIGNMENT_DECOMPOSE_FIT {
     tag "$meta.id"
     label 'process_medium'
 
@@ -6,7 +6,8 @@ process SIGPROFILERASSIGNMENT {
 
     input:
     tuple val(meta), val(type), path(matrix)
-    path(reference_signatures)
+    path (extracted_signatures)
+    path (reference_signatures)
 
     output:
     tuple val(meta), path("**.pdf")                                         , emit: plots
@@ -27,20 +28,21 @@ process SIGPROFILERASSIGNMENT {
     export SIGPROFILERPLOTTING_VOLUME='./spa_volume'
     export SIGPROFILERASSIGNMENT_VOLUME='./spa_volume'
 
-    SigProfilerAssignment cosmic_fit \\
+    SigProfilerAssignment decompose_fit \\
             ${matrix} \\
-            output_${name} \\
-            --signatures ${reference_signatures} \\
+            signature_decomposition_${name} \\
+            --signatures ${extracted_signatures} \\
+            --signature_database ${reference_signatures} \\
             --genome_build ${assembly} \\
             --cpu ${task.cpus} \\
             --volume spa_volume
 
-    mv output_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.txt output_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.${name}.txt;
+    #mv signature_decomposition_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.txt signature_decomposition_${name}/Assignment_Solution/Activities/Decomposed_MutationType_Probabilities.${name}.txt;
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')
-        SigProfilerAssignment : 0.1.1
+        SigProfilerAssignment : 1.1.3
     END_VERSIONS
     """
 
@@ -53,7 +55,7 @@ process SIGPROFILERASSIGNMENT {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')
-        SigProfilerAssignment : 0.1.1
+        SigProfilerAssignment : 1.1.3
     END_VERSIONS
     """
 }

--- a/modules/local/signatures/sigprofiler/extractor/main.nf
+++ b/modules/local/signatures/sigprofiler/extractor/main.nf
@@ -25,7 +25,7 @@ process SIGPROFILEREXTRACTOR {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: ""
     prefix = "${meta.id}${prefix}"
-    def assembly = task.ext.assembly ?: "GRCh38"
+    def assembly = task.ext.genome_assembly ?: "GRCh38"
     // python -c "from SigProfilerAssignment import Analyzer as Analyze; Analyze.cosmic_fit('${matrix}', 'output', input_type='matrix', context_type='96',
     //                    collapse_to_SBS96=True, cosmic_version=3.4, exome=False,
     //                    genome_build="GRCh38", signature_database='${reference_signatures}',

--- a/modules/local/signatures/sigprofiler/matrixgenerator/main.nf
+++ b/modules/local/signatures/sigprofiler/matrixgenerator/main.nf
@@ -34,7 +34,6 @@ process SIGPROFILER_MATRIXGENERATOR {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
         SigProfilerMatrixGenerator: 1.3.5
     END_VERSIONS
     """
@@ -43,7 +42,6 @@ process SIGPROFILER_MATRIXGENERATOR {
     """
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
         SigProfilerMatrixGenerator: 1.3.5
     END_VERSIONS
     """

--- a/modules/local/signatures/sigprofiler/matrixgenerator/main.nf
+++ b/modules/local/signatures/sigprofiler/matrixgenerator/main.nf
@@ -1,5 +1,5 @@
 process SIGPROFILER_MATRIXGENERATOR {
-    tag "${task.ext.prefix}"
+    tag "samples"
     label 'process_single'
 
     container 'docker.io/ferriolcalvet/sigprofilermatrixgenerator:1.3.5'
@@ -8,11 +8,11 @@ process SIGPROFILER_MATRIXGENERATOR {
     path (vcf)
 
     output:
-    path("input_mutations/output/plots/*"), optional : true, emit: output_plots
-    path("input_mutations/output/ID/*")   , optional : true, emit: matrices_ID
-    path("input_mutations/output/DBS/*")  , optional : true, emit: matrices_DBS
-    path("input_mutations/output/SBS/*")  , optional : true, emit: matrices_SBS
-    path("input_mutations/output/TSB/*")  , optional : true, emit: transcription_bias
+    path("**plots/*"), optional : true, emit: output_plots
+    path("**ID/*")   , optional : true, emit: matrices_ID
+    path("**DBS/*")  , optional : true, emit: matrices_DBS
+    path("**SBS/*")  , optional : true, emit: matrices_SBS
+    path("**TSB/*")  , optional : true, emit: transcription_bias
     path "versions.yml"                                    , topic: versions
 
 
@@ -21,6 +21,11 @@ process SIGPROFILER_MATRIXGENERATOR {
     def args = task.ext.args ?: ""
     def genome = task.ext.genome_assembly ?: "GRCh38"
     """
+    mkdir -p spa_volume
+    export SIGPROFILERMATRIXGENERATOR_VOLUME='./spa_volume'
+    export SIGPROFILERPLOTTING_VOLUME='./spa_volume'
+    export SIGPROFILERASSIGNMENT_VOLUME='./spa_volume'
+
     mkdir input_mutations
     cp *.vcf input_mutations/.
 
@@ -28,7 +33,11 @@ process SIGPROFILER_MATRIXGENERATOR {
                 ${prefix} \\
                 ${genome} \\
                 input_mutations/ \\
+                --volume spa_volume \\
                 ${args}
+            
+    mv input_mutations/output/ ${prefix}_output/
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')

--- a/modules/local/signatures/sigprofiler/matrixgenerator/main.nf
+++ b/modules/local/signatures/sigprofiler/matrixgenerator/main.nf
@@ -21,11 +21,6 @@ process SIGPROFILER_MATRIXGENERATOR {
     def args = task.ext.args ?: ""
     def genome = task.ext.genome_assembly ?: "GRCh38"
     """
-    mkdir -p spa_volume
-    export SIGPROFILERMATRIXGENERATOR_VOLUME='./spa_volume'
-    export SIGPROFILERPLOTTING_VOLUME='./spa_volume'
-    export SIGPROFILERASSIGNMENT_VOLUME='./spa_volume'
-
     mkdir input_mutations
     cp *.vcf input_mutations/.
 
@@ -33,7 +28,6 @@ process SIGPROFILER_MATRIXGENERATOR {
                 ${prefix} \\
                 ${genome} \\
                 input_mutations/ \\
-                --volume spa_volume \\
                 ${args}
             
     mv input_mutations/output/ ${prefix}_output/

--- a/subworkflows/local/adjmutdensity/main.nf
+++ b/subworkflows/local/adjmutdensity/main.nf
@@ -1,4 +1,4 @@
-include { TABIX_BGZIPTABIX_QUERY    as QUERYMUTATIONS          } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
+include { TABIX_BGZIPTABIX_QUERY    as QUERYMUTATIONS           } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
 
 include { SUBSET_MAF                as SUBSETMUTDENSITYADJUSTED } from '../../../modules/local/subsetmaf/main'
 
@@ -16,7 +16,7 @@ workflow MUTATION_DENSITY {
 
     main:
 
-    // Intersect BED of all sites with BED of sample filtered sites
+    // Intersect BED of all sites of interest with mutations
     QUERYMUTATIONS(mutations, bedfile)
 
     SUBSETMUTDENSITYADJUSTED(QUERYMUTATIONS.out.subset)

--- a/subworkflows/local/dnds/main.nf
+++ b/subworkflows/local/dnds/main.nf
@@ -1,5 +1,3 @@
-include { TABIX_BGZIPTABIX_QUERY    as QUERYMUTATIONS          } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
-
 include { SUBSET_MAF                as SUBSET_DNDS              } from '../../../modules/local/subsetmaf/main'
 
 include { PREPROCESS_DNDS           as PREPROCESSDEPTHS         } from '../../../modules/local/dnds/preprocess/main'
@@ -10,7 +8,6 @@ workflow DNDS {
     take:
     mutations
     depth
-    bedfile
     panel
 
     main:
@@ -18,10 +15,7 @@ workflow DNDS {
     covariates = params.dnds_covariates ? channel.fromPath( params.dnds_covariates, checkIfExists: true).first() : channel.empty()
     ref_trans = params.dnds_ref_transcripts ? channel.fromPath( params.dnds_ref_transcripts, checkIfExists: true).first() : channel.empty()
 
-
-    QUERYMUTATIONS(mutations, bedfile)
-
-    SUBSET_DNDS(QUERYMUTATIONS.out.subset)
+    SUBSET_DNDS(mutations)
 
     PREPROCESSDEPTHS(depth, panel)
 

--- a/subworkflows/local/mutability/main.nf
+++ b/subworkflows/local/mutability/main.nf
@@ -1,6 +1,4 @@
 
-include { TABIX_BGZIPTABIX_QUERY        as QUERYMUTATIONS          } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
-
 include { SUBSET_MAF                    as SUBSETMUTABILITY         } from '../../../modules/local/subsetmaf/main'
 
 include { COMPUTE_RELATIVE_MUTABILITY   as RELATIVEMUTABILITY       } from '../../../modules/local/compute_mutability/main'

--- a/subworkflows/local/mutability/main.nf
+++ b/subworkflows/local/mutability/main.nf
@@ -16,19 +16,10 @@ workflow MUTABILITY {
     depth
     profile
     panel_file
-    bedfiles
 
     main:
-    // actual code
 
-    // this line was not needed nor used in the computation of mutabilities,
-    // since there is an additional left_join merge in the compute mutabilities code,
-    // the depths can be the full ones
-    // QUERYDEPTHS(depth, bedfiles)
-    QUERYMUTATIONS(mutations, bedfiles)
-
-
-    SUBSETMUTABILITY(QUERYMUTATIONS.out.subset)
+    SUBSETMUTABILITY(mutations)
     SUBSETMUTABILITY.out.mutations
     .join(profile)
     .join(depth)

--- a/subworkflows/local/mutationprofile/main.nf
+++ b/subworkflows/local/mutationprofile/main.nf
@@ -50,7 +50,7 @@ workflow MUTATIONAL_PROFILE {
     compile_all_profiles = COMPUTEPROFILE.out.profile.map{ it -> it[1] }.collect().map { files -> [ [id:'all_profiles'], files ] }
     CONCATPROFILES(compile_all_profiles, all_groups)
 
-    compile_stabilities = COMPUTEPROFILE.out.profile_stability.map{ it -> it[1] }.collect()
+    compile_stabilities = COMPUTEPROFILE.out.profile_stability.map{ it -> it[1] }.collect().map { files -> [ [id:'all_stabilities'], files ] }
 
 
     emit:

--- a/subworkflows/local/mutationprofile/main.nf
+++ b/subworkflows/local/mutationprofile/main.nf
@@ -50,10 +50,14 @@ workflow MUTATIONAL_PROFILE {
     compile_all_profiles = COMPUTEPROFILE.out.profile.map{ it -> it[1] }.collect().map { files -> [ [id:'all_profiles'], files ] }
     CONCATPROFILES(compile_all_profiles, all_groups)
 
+    compile_stabilities = COMPUTEPROFILE.out.profile_stability.map{ it -> it[1] }.collect()
+
+
     emit:
-    profile         = COMPUTEPROFILE.out.profile            // channel: [ val(meta), file(profile) ]
-    matrix_sigprof  = sigprofiler_matrix
-    trinucleotides  = COMPUTETRINUC.out.trinucleotides
-    wgs_sigprofiler = sigprofiler_wgs
-    compiled_profiles = CONCATPROFILES.out.compiled_profiles
+    profile             = COMPUTEPROFILE.out.profile            // channel: [ val(meta), file(profile) ]
+    matrix_sigprof      = sigprofiler_matrix
+    trinucleotides      = COMPUTETRINUC.out.trinucleotides
+    wgs_sigprofiler     = sigprofiler_wgs
+    compiled_profiles   = CONCATPROFILES.out.compiled_profiles
+    profile_stabilities = compile_stabilities
 }

--- a/subworkflows/local/omega/main.nf
+++ b/subworkflows/local/omega/main.nf
@@ -45,12 +45,10 @@ workflow OMEGA_ANALYSIS{
     all_gloc_results        = channel.empty()
 
     // Intersect BED of all sites with BED of sample filtered sites
-    QUERYMUTATIONS(mutations, bedfile)
-
     QUERYPANEL(panel_captured_rich, bedfile)
 
-    SUBSETOMEGA(QUERYMUTATIONS.out.subset)
-    SUBSETOMEGAMULTI(QUERYMUTATIONS.out.subset)
+    SUBSETOMEGA(mutations)
+    SUBSETOMEGAMULTI(mutations)
 
     SUBSETOMEGA.out.mutations
     .join( depth )

--- a/subworkflows/local/omega/main.nf
+++ b/subworkflows/local/omega/main.nf
@@ -1,10 +1,7 @@
-include { TABIX_BGZIPTABIX_QUERY    as QUERYMUTATIONS          } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
 include { SUBSET_MAF                as SUBSETOMEGA              } from '../../../modules/local/subsetmaf/main'
 include { SUBSET_MAF                as SUBSETOMEGAMULTI         } from '../../../modules/local/subsetmaf/main'
 
-
-
-include { TABIX_BGZIPTABIX_QUERY    as QUERYPANEL              } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
+include { TABIX_BGZIPTABIX_QUERY    as QUERYPANEL               } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
 
 include { OMEGA_PREPROCESS          as PREPROCESSING            } from '../../../modules/local/bbgtools/omega/preprocess/main'
 include { GROUP_GENES               as GROUPGENES               } from '../../../modules/local/group_genes/main'
@@ -17,10 +14,10 @@ include { PLOT_OMEGASYN_QC          as EVALOMEGAGLOCESTIMATION  } from '../../..
 
 include { OMEGA_PREPROCESS          as PREPROCESSINGGLOBALLOC   } from '../../../modules/local/bbgtools/omega/preprocess/main'
 include { OMEGA_ESTIMATOR           as ESTIMATORGLOBALLOC       } from '../../../modules/local/bbgtools/omega/estimator/main'
-include { OMEGA_MUTABILITIES        as ABSOLUTEMUTABILITIESGLOBALLOC       } from '../../../modules/local/bbgtools/omega/mutabilities/main'
-include { PLOT_OMEGA                as PLOTOMEGAGLOBALLOC       } from '../../../modules/local/plot/omega/main'
-include { SITE_COMPARISON           as SITECOMPARISONGLOBALLOC  } from '../../../modules/local/bbgtools/sitecomparison/main'
-include { SITE_COMPARISON           as SITECOMPARISONGLOBALLOCMULTI  } from '../../../modules/local/bbgtools/sitecomparison/main'
+include { OMEGA_MUTABILITIES        as ABSOLUTEMUTABILITIESGLOBALLOC    } from '../../../modules/local/bbgtools/omega/mutabilities/main'
+include { PLOT_OMEGA                as PLOTOMEGAGLOBALLOC               } from '../../../modules/local/plot/omega/main'
+include { SITE_COMPARISON           as SITECOMPARISONGLOBALLOC          } from '../../../modules/local/bbgtools/sitecomparison/main'
+include { SITE_COMPARISON           as SITECOMPARISONGLOBALLOCMULTI     } from '../../../modules/local/bbgtools/sitecomparison/main'
 
 workflow OMEGA_ANALYSIS{
 
@@ -79,7 +76,7 @@ workflow OMEGA_ANALYSIS{
     ESTIMATOR( preprocess_n_depths, expanded_panel, GROUPGENES.out.json_genes.first())
 
     if (params.omega_plot){
-        QUERYMUTATIONS.out.subset
+        mutations
         .join(ESTIMATOR.out.results)
         .set{mutations_n_omega}
 
@@ -134,7 +131,7 @@ workflow OMEGA_ANALYSIS{
         EVALOMEGAGLOCESTIMATION(all_syn_muts, all_syn_muts_gloc, grouping_defs)
 
         if (params.omega_plot){
-            QUERYMUTATIONS.out.subset
+            mutations
             .join(ESTIMATORGLOBALLOC.out.results)
             .set{mutations_n_omegagloloc}
 

--- a/subworkflows/local/oncodrive3d/main.nf
+++ b/subworkflows/local/oncodrive3d/main.nf
@@ -14,15 +14,13 @@ workflow ONCODRIVE3D_ANALYSIS{
     take:
     mutations
     mutabilities
-    bedfile
     datasets
     annotations
     raw_vep
 
     main:
 
-    QUERYMUTATIONS(mutations, bedfile)
-    SUBSETONCODRIVE3D(QUERYMUTATIONS.out.subset)
+    SUBSETONCODRIVE3D(mutations)
 
     // mutations preprocessing
     if (params.o3d_raw_vep){

--- a/subworkflows/local/oncodrive3d/main.nf
+++ b/subworkflows/local/oncodrive3d/main.nf
@@ -1,5 +1,3 @@
-include { TABIX_BGZIPTABIX_QUERY    as QUERYMUTATIONS      } from '../../../modules/nf-core/tabix/bgziptabixquery/main'
-
 include { SUBSET_MAF                as SUBSETONCODRIVE3D    } from '../../../modules/local/subsetmaf/main'
 
 include { ONCODRIVE3D_PREPROCESSING                         } from '../../../modules/local/bbgtools/oncodrive3d/preprocessing/main'

--- a/subworkflows/local/oncodriveclustl/main.nf
+++ b/subworkflows/local/oncodriveclustl/main.nf
@@ -1,6 +1,6 @@
 include { CREATECUSTOMBEDFILE    as ONCODRIVECLUSTLBED     } from '../../../modules/local/createpanels/custombedfile/main'
 
-include { SUBSET_MAF             as SUBSETONCODRIVECLUSTL } from '../../../modules/local/subsetmaf/main'
+include { SUBSET_MAF             as SUBSETONCODRIVECLUSTL  } from '../../../modules/local/subsetmaf/main'
 
 include { ONCODRIVECLUSTL                                  } from '../../../modules/local/bbgtools/oncodriveclustl/main'
 // include { ONCODRIVECLUSTL           as ONCODRIVECLUSTLSNVS    } from '../../../modules/local/bbgtools/oncodriveclustl/main'

--- a/subworkflows/local/signatures/main.nf
+++ b/subworkflows/local/signatures/main.nf
@@ -1,7 +1,8 @@
-include { MATRIX_CONCAT                 as MATRIXCONCATWGS          } from '../../../modules/local/sig_matrix_concat/main'
-include { SIGPROFILERASSIGNMENT                                     } from '../../../modules/local/signatures/sigprofiler/assignment/main'
-include { SIGNATURES_PROBABILITIES      as SIGPROBS                 } from '../../../modules/local/combine_sbs/main'
-include { HDP_EXTRACTION                as HDPEXTRACTION            } from '../signatures_hdp/main'
+include { MATRIX_CONCAT                         as MATRIXCONCATWGS          } from '../../../modules/local/sig_matrix_concat/main'
+include { SIGPROFILERASSIGNMENT_COSMIC_FIT      as SIGPROFILERASSIGNMENT    } from '../../../modules/local/signatures/sigprofiler/assignment/cosmic_fit/main'
+include { SIGPROFILERASSIGNMENT_DECOMPOSE_FIT   as HDPREASSIGNMENT          } from '../../../modules/local/signatures/sigprofiler/assignment/decompose_fit/main'
+include { SIGNATURES_PROBABILITIES              as SIGPROBS                 } from '../../../modules/local/combine_sbs/main'
+include { HDP_EXTRACTION                        as HDPEXTRACTION            } from '../signatures_hdp/main'
 
 
 workflow SIGNATURES {
@@ -38,6 +39,7 @@ workflow SIGNATURES {
 
     HDPEXTRACTION(named_matrices_wgs_hdp, reference_signatures)
 
+    HDPREASSIGNMENT(named_matrices_wgs_sp, HDPEXTRACTION.out.signatures, reference_signatures)
 
     emit:
     plots               = SIGPROFILERASSIGNMENT.out.plots       // channel: [ val(meta), file(depths) ]

--- a/subworkflows/local/signatures/main.nf
+++ b/subworkflows/local/signatures/main.nf
@@ -39,7 +39,7 @@ workflow SIGNATURES {
 
     HDPEXTRACTION(named_matrices_wgs_hdp, reference_signatures)
 
-    HDPREASSIGNMENT(named_matrices_wgs_sp, HDPEXTRACTION.out.signatures, reference_signatures)
+    HDPREASSIGNMENT(named_matrices_wgs_sp, HDPEXTRACTION.out.signatures.first(), reference_signatures)
 
     emit:
     plots               = SIGPROFILERASSIGNMENT.out.plots       // channel: [ val(meta), file(depths) ]

--- a/subworkflows/local/signatures_hdp/main.nf
+++ b/subworkflows/local/signatures_hdp/main.nf
@@ -1,9 +1,8 @@
 include { PREPARE_INPUT                                         } from '../../../modules/local/signatures/hdp/prepareinput/main'
 include { RUN_HDP_CHAIN_SAMPLING                                } from '../../../modules/local/signatures/hdp/chainsampling/main'
 include { PROCESS_HDP_RESULTS                                   } from '../../../modules/local/signatures/hdp/process_results/main'
-include { COMPARE_SIGNATURES as COMPARESIGNATURES               } from '../../../modules/local/signatures/hdp/compare_sigs/main'
-
-
+include { COMPARE_SIGNATURES            as COMPARESIGNATURES    } from '../../../modules/local/signatures/hdp/compare_sigs/main'
+include { SIGNATURES_HDP_TO_SIGPROFILER as REFORMATSIGNATURES   } from '../../../modules/local/signatures/hdp/reformat_sigs/main'
 
 
 workflow HDP_EXTRACTION {
@@ -32,9 +31,11 @@ workflow HDP_EXTRACTION {
 
     COMPARESIGNATURES(PROCESS_HDP_RESULTS.out.processed_results, reference_signatures)
 
+    REFORMATSIGNATURES(PROCESS_HDP_RESULTS.out.processed_results)
 
-    // emit:
-    // plots               = SIGPROFILERASSIGNMENT.out.plots       // channel: [ val(meta), file(depths) ]
-    // // plots_extraction    = MSIGHDP.out.plots                     // channel: [ val(meta), file(depths) ]
+
+    emit:
+    signatures      = REFORMATSIGNATURES.out.signatures_for_sp     // channel: [ val(meta), file(depths) ]
+    // plots_extraction    = MSIGHDP.out.plots                  // channel: [ val(meta), file(depths) ]
     // mutation_probs      = signature_probs_samples
 }

--- a/subworkflows/local/signatures_hdp/main.nf
+++ b/subworkflows/local/signatures_hdp/main.nf
@@ -31,7 +31,7 @@ workflow HDP_EXTRACTION {
 
     COMPARESIGNATURES(PROCESS_HDP_RESULTS.out.processed_results, reference_signatures)
 
-    REFORMATSIGNATURES(PROCESS_HDP_RESULTS.out.processed_results)
+    REFORMATSIGNATURES(PROCESS_HDP_RESULTS.out.signatures)
 
 
     emit:

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -292,7 +292,7 @@ workflow DEEPCSA{
     // Mutational profile
     if ( params.profileall || run_mutabilities || params.omega ){
         MUTPROFILEALL(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.all_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
-        all_compiled_stabilities = all_compiled_stabilities.mix(MUTPROFILEALL.out.profile_stabilities.map{ it -> it[1] })
+        all_compiled_stabilities = all_compiled_stabilities.concat(MUTPROFILEALL.out.profile_stabilities.map{ it -> it[1] })
         if (run_mutdensity){
             
             // TODO explore if we could use the ALL consensus panel instead of the exons one
@@ -311,19 +311,18 @@ workflow DEEPCSA{
     }
     if (params.profilenonprot){
         MUTPROFILENONPROT(somatic_mutations, DEPTHSNONPROTCONS.out.subset, CREATEPANELS.out.nonprot_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
-        all_compiled_stabilities = all_compiled_stabilities.mix(MUTPROFILENONPROT.out.profile_stabilities.map{ it -> it[1] })
+        all_compiled_stabilities = all_compiled_stabilities.concat(MUTPROFILENONPROT.out.profile_stabilities.map{ it -> it[1] })
     }
     if (params.profileexons){
         MUTPROFILEEXONS(somatic_mutations, DEPTHSEXONSCONS.out.subset, CREATEPANELS.out.exons_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
-        all_compiled_stabilities = all_compiled_stabilities.mix(MUTPROFILEEXONS.out.profile_stabilities.map{ it -> it[1] })
+        all_compiled_stabilities = all_compiled_stabilities.concat(MUTPROFILEEXONS.out.profile_stabilities.map{ it -> it[1] })
     }
     if (params.profileintrons){
         DEPTHSINTRONSCONS(annotated_depths, CREATEPANELS.out.introns_consensus_bed)
         MUTPROFILEINTRONS(somatic_mutations, DEPTHSINTRONSCONS.out.subset, CREATEPANELS.out.introns_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
-        all_compiled_stabilities = all_compiled_stabilities.mix(MUTPROFILEINTRONS.out.profile_stabilities.map{ it -> it[1] })
+        all_compiled_stabilities = all_compiled_stabilities.concat(MUTPROFILEINTRONS.out.profile_stabilities.map{ it -> it[1] })
     }
-    
-    all_compiled_stabilities.collectFile(name: "all_profile_stabilities.tsv", storeDir:"${params.outdir}/mutational_profile", skip: 1, keepHeader: true)
+    all_compiled_stabilities.flatten().collectFile(name: "all_profile_stabilities.tsv", storeDir:"${params.outdir}/mutational_profile", skip: 1, keepHeader: true)
 
 
     if (run_mutabilities) {

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -576,7 +576,7 @@ workflow DEEPCSA{
                 // DNA2PROTEINMAPPING.out.depths_exons_positions
                 )
 
-    if (params.omega || params.oncodrive3d || params.oncodrivefml || params.indels) {
+    if (params.omega || params.oncodrive3d || params.oncodrivefml || params.indels || run_mutdensity) {
         if (params.omega){
             positive_selection_results = positive_selection_results.combine(PLOTTINGQC.out.flagged_omegas)
         }

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -150,7 +150,7 @@ workflow DEEPCSA{
     all_compiled_omegas             = channel.empty()
     all_compiled_omegasgloballoc    = channel.empty()
     all_mutdensities_file           = channel.empty()
-
+    all_compiled_stabilities        = channel.empty()
 
     // if the user wants to use custom gene groups, import the gene groups table
     // otherwise I am using the input csv as a dummy value channel
@@ -292,6 +292,7 @@ workflow DEEPCSA{
     // Mutational profile
     if ( params.profileall || run_mutabilities || params.omega ){
         MUTPROFILEALL(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.all_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
+        all_compiled_stabilities = all_compiled_stabilities.mix(MUTPROFILEALL.out.profile_stabilities.map{ it -> it[1] })
         if (run_mutdensity){
             
             // TODO explore if we could use the ALL consensus panel instead of the exons one
@@ -310,14 +311,19 @@ workflow DEEPCSA{
     }
     if (params.profilenonprot){
         MUTPROFILENONPROT(somatic_mutations, DEPTHSNONPROTCONS.out.subset, CREATEPANELS.out.nonprot_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
+        all_compiled_stabilities = all_compiled_stabilities.mix(MUTPROFILENONPROT.out.profile_stabilities.map{ it -> it[1] })
     }
     if (params.profileexons){
         MUTPROFILEEXONS(somatic_mutations, DEPTHSEXONSCONS.out.subset, CREATEPANELS.out.exons_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
+        all_compiled_stabilities = all_compiled_stabilities.mix(MUTPROFILEEXONS.out.profile_stabilities.map{ it -> it[1] })
     }
     if (params.profileintrons){
         DEPTHSINTRONSCONS(annotated_depths, CREATEPANELS.out.introns_consensus_bed)
         MUTPROFILEINTRONS(somatic_mutations, DEPTHSINTRONSCONS.out.subset, CREATEPANELS.out.introns_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
+        all_compiled_stabilities = all_compiled_stabilities.mix(MUTPROFILEINTRONS.out.profile_stabilities.map{ it -> it[1] })
     }
+    
+    all_compiled_stabilities.collectFile(name: "all_profile_stabilities.tsv", storeDir:"${params.outdir}/mutational_profile", skip: 1, keepHeader: true)
 
 
     if (run_mutabilities) {

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -400,7 +400,6 @@ workflow DEEPCSA{
     if (params.dnds){
         DNDS(mutations_in_exons,
                     DEPTHSEXONSCONS.out.subset,
-                    CREATEPANELS.out.exons_consensus_bed,
                     CREATEPANELS.out.exons_consensus_panel
                     )
     }

--- a/workflows/deepcsa.nf
+++ b/workflows/deepcsa.nf
@@ -101,6 +101,8 @@ include { TABLE_2_GROUP                 as TABLE2GROUP              } from '../m
 include { ANNOTATE_DEPTHS               as ANNOTATEDEPTHS           } from '../modules/local/annotatedepth/main'
 include { DOWNSAMPLE_DEPTHS             as DOWNSAMPLEDEPTHS         } from '../modules/local/downsample/depths/main'
 
+include { TABIX_BGZIPTABIX_QUERY        as QUERYMUTATIONSEXONS      } from '../modules/nf-core/tabix/bgziptabixquery/main'
+
 include { SELECT_MUTDENSITIES           as SYNMUTDENSITY            } from '../modules/local/select_mutdensity/main'
 include { SELECT_MUTDENSITIES           as SYNMUTREADSDENSITY       } from '../modules/local/select_mutdensity/main'
 
@@ -282,11 +284,18 @@ workflow DEEPCSA{
 
     }
 
+    // Intersect BED of all sites with somatic mutations to keep only those mutations in the exons consensus panel
+    QUERYMUTATIONSEXONS(somatic_mutations, CREATEPANELS.out.exons_consensus_bed)
+    mutations_in_exons = QUERYMUTATIONSEXONS.out.subset
+
 
     // Mutational profile
     if ( params.profileall || run_mutabilities || params.omega ){
         MUTPROFILEALL(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.all_consensus_bed, wgs_trinucs, TABLE2GROUP.out.json_allgroups)
         if (run_mutdensity){
+            
+            // TODO explore if we could use the ALL consensus panel instead of the exons one
+            //      I am suggesting this since we are already distinguishing per consequence type within the script
             MUTDENSITYADJUSTED(somatic_mutations, DEPTHSALLCONS.out.subset, CREATEPANELS.out.exons_consensus_bed, CREATEPANELS.out.exons_consensus_panel, MUTPROFILEALL.out.profile, wgs_trinucs)
 
             // Concatenate all outputs into a single file
@@ -313,19 +322,17 @@ workflow DEEPCSA{
 
     if (run_mutabilities) {
         if (params.profileall){
-            MUTABILITYALL(somatic_mutations,
+            MUTABILITYALL(mutations_in_exons,
                             annotated_depths,
                             MUTPROFILEALL.out.profile,
-                            CREATEPANELS.out.exons_consensus_panel,
-                            CREATEPANELS.out.exons_consensus_bed
+                            CREATEPANELS.out.exons_consensus_panel
                             )
         }
         if (params.profilenonprot){
-            MUTABILITYNONPROT(somatic_mutations,
+            MUTABILITYNONPROT(mutations_in_exons,
                                 annotated_depths,
                                 MUTPROFILENONPROT.out.profile,
-                                CREATEPANELS.out.exons_consensus_panel,
-                                CREATEPANELS.out.exons_consensus_bed
+                                CREATEPANELS.out.exons_consensus_panel
                                 )
         }
     }
@@ -356,7 +363,7 @@ workflow DEEPCSA{
         oncodrivefml_regressions_files = channel.empty()
         if (params.profileall){
             mode = "all"
-            ONCODRIVEFMLALL(somatic_mutations, MUTABILITYALL.out.mutability,
+            ONCODRIVEFMLALL(mutations_in_exons, MUTABILITYALL.out.mutability,
                                 CREATEPANELS.out.exons_consensus_panel,
                                 cadd_scores, mode
                             )
@@ -368,7 +375,7 @@ workflow DEEPCSA{
         }
         if (params.profilenonprot && params.positive_selection_non_protein_affecting){
             mode = "non_prot_aff"
-            ONCODRIVEFMLNONPROT(somatic_mutations, MUTABILITYNONPROT.out.mutability,
+            ONCODRIVEFMLNONPROT(mutations_in_exons, MUTABILITYNONPROT.out.mutability,
                                     CREATEPANELS.out.exons_consensus_panel,
                                     cadd_scores, mode
                                 )
@@ -381,7 +388,7 @@ workflow DEEPCSA{
     if (params.oncodrive3d){
         if (params.profileall){
             // Oncodrive3D
-            ONCODRIVE3D(somatic_mutations, MUTABILITYALL.out.mutability, CREATEPANELS.out.exons_consensus_bed,
+            ONCODRIVE3D(mutations_in_exons, MUTABILITYALL.out.mutability,
                         datasets3d, annotations3d, MUT_PREPROCESSING.out.all_raw_vep_annotation)
             positive_selection_results = positive_selection_results.join(ONCODRIVE3D.out.results, remainder: true)
             positive_selection_results = positive_selection_results.join(ONCODRIVE3D.out.results_pos, remainder: true)
@@ -391,7 +398,7 @@ workflow DEEPCSA{
 
     // if (params.expected_mutated_cells & params.dnds){
     if (params.dnds){
-        DNDS(somatic_mutations,
+        DNDS(mutations_in_exons,
                     DEPTHSEXONSCONS.out.subset,
                     CREATEPANELS.out.exons_consensus_bed,
                     CREATEPANELS.out.exons_consensus_panel
@@ -404,7 +411,7 @@ workflow DEEPCSA{
 
         // Omega
         if (params.profileall){
-            OMEGA(somatic_mutations,
+            OMEGA(mutations_in_exons,
                     DEPTHSEXONSCONS.out.subset,
                     MUTPROFILEALL.out.profile,
                     CREATEPANELS.out.exons_consensus_bed.first(),
@@ -434,7 +441,7 @@ workflow DEEPCSA{
 
             if (params.omega_multi){
                 // Omega multi
-                OMEGAMULTI(somatic_mutations,
+                OMEGAMULTI(mutations_in_exons,
                             DEPTHSEXONSCONS.out.subset,
                             MUTPROFILEALL.out.profile,
                             CREATEPANELS.out.exons_consensus_bed.first(),
@@ -457,7 +464,7 @@ workflow DEEPCSA{
             }
         }
         if (params.profilenonprot && params.positive_selection_non_protein_affecting){
-            OMEGANONPROT(somatic_mutations,
+            OMEGANONPROT(mutations_in_exons,
                             DEPTHSEXONSCONS.out.subset,
                             MUTPROFILENONPROT.out.profile,
                             CREATEPANELS.out.exons_consensus_bed.first(),
@@ -475,7 +482,7 @@ workflow DEEPCSA{
             }
 
             if (params.omega_multi){
-                OMEGANONPROTMULTI(somatic_mutations,
+                OMEGANONPROTMULTI(mutations_in_exons,
                                     DEPTHSEXONSCONS.out.subset,
                                     MUTPROFILENONPROT.out.profile,
                                     CREATEPANELS.out.exons_consensus_bed.first(),


### PR DESCRIPTION
## Main update: extracted signatures decomposition
The main update is to do the decomposition of the mutational signatures extracted by HDP using SigProfilerAssignment.
This results in a much cleaner assignment of mutational signatures to samples. See example below:

SigProfilerAssignment directly:
<img width="368" height="561" alt="image" src="https://github.com/user-attachments/assets/e4c47f99-0a60-4264-831b-cdd32864b624" />


Results of SigProfilerAssignment decomposition using the signatures extracted by HDP:
<img width="368" height="561" alt="image" src="https://github.com/user-attachments/assets/ccf3a75c-0329-4851-8afa-b34d791d1c75" />


### Minor fixes
- Remove all mentions to hg19 and mm10 these are not supported anymore
- Remove some duplicated mutation subsets for exonic mutations

